### PR TITLE
feat: 할일 페이지 주간업무표, 그룹원 리스트 UI 구현 

### DIFF
--- a/src/features/tasks/components/HistoryModal.tsx
+++ b/src/features/tasks/components/HistoryModal.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { XCircleFill } from 'react-bootstrap-icons'
+
+export interface TaskHistory {
+  date: string
+  task: string
+  status: '완료' | '미완료'
+}
+interface HistoryModalProps {
+  open: boolean
+  onClose: () => void
+  items: TaskHistory[]
+}
+
+const HistoryModal: React.FC<HistoryModalProps> = ({ open, onClose, items }) => {
+  if (!open) return null
+
+  return (
+    <dialog open className="modal">
+      <div className="modal-box max-w-lg h-[90vh] px-4 py-7 overflow-y-auto">
+        <button
+          className="btn btn-xs btn-circle btn-ghost absolute right-4 top-4"
+          onClick={onClose}
+        >
+          <XCircleFill className="text-2xl text-gray-400" />
+        </button>
+        <h2 className="text-center text-2xl font-bold mb-5">업무 내역</h2>
+
+        {/* 필터 */}
+        <div className="flex justify-end mb-2">
+          <select className="select select-bordered select-sm w-32 bg-base-100" disabled>
+            <option>전체보기</option>
+          </select>
+        </div>
+
+        {/* 내역 리스트 */}
+        <div className="flex flex-col space-y-2">
+          {items.map((item, idx) => (
+            <div
+              key={idx}
+              className="
+                card card-bordered bg-base-100 flex-row items-center 
+                px-4 py-2.5 border-gray-100 shadow-none
+              "
+            >
+              <div className="font-bold mr-1.5 min-w-[100px]">{item.date}</div>
+              <div className="flex-1 text-md">{item.task}</div>
+              <span
+                className={`
+                  badge h-9 w-20
+                  py-3 ml-3 rounded-lg
+                  font-semibold border-none
+                  ${item.status === '완료' ? 'bg-gray-400 text-white' : 'bg-gray-100 text-gray-500'}
+                `}
+              >
+                {item.status}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <form method="dialog" className="modal-backdrop !fixed !inset-0 !bg-black/40">
+        <button onClick={onClose}>close</button>
+      </form>
+    </dialog>
+  )
+}
+
+export default HistoryModal

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -17,7 +17,7 @@ const TasksPage: React.FC = () => {
   const [repeat, setRepeat] = React.useState(true)
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-primary">주간 업무표</h1>
         <TaskHistoryButton onClick={() => {}} />

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useState } from 'react'
 import TaskHistoryButton from '../features/tasks/components/TaskHistoryButton'
 import TaskTable from '../features/tasks/components/TaskTable'
 import TaskRandomButton from '../features/tasks/components/TaskRandomButton'
 import TaskExchangeButton from '../features/tasks/components/TaskExchangeButton'
 import CheckRepeat from '../features/tasks/components/CheckRepeat'
 import GroupMemberList from '../features/tasks/components/GroupMemberList'
+import HistoryModal, { TaskHistory } from '../features/tasks/components/HistoryModal'
 /* 그룹장 화면 기준 ui */
 
 const members = [
@@ -13,14 +14,24 @@ const members = [
   { name: '그룹원3', avatarUrl: '/' },
 ]
 
+const historyItems: TaskHistory[] = [
+  { date: '2025.07.29', task: '청소', status: '미완료' },
+  { date: '2025.07.21', task: '분리수거', status: '완료' },
+  { date: '2025.07.18', task: '설거지', status: '완료' },
+  { date: '2025.07.12', task: '청소', status: '미완료' },
+  { date: '2025.07.10', task: '설거지', status: '완료' },
+  { date: '2025.07.07', task: '분리수거', status: '완료' },
+]
+
 const TasksPage: React.FC = () => {
   const [repeat, setRepeat] = React.useState(true)
+  const [showHistory, setShowHistory] = useState(false)
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-primary">주간 업무표</h1>
-        <TaskHistoryButton onClick={() => {}} />
+        <TaskHistoryButton onClick={() => setShowHistory(true)} />
       </div>
       <TaskTable />
       <div className="flex flex-col items-center space-y-4 mt-2">
@@ -32,6 +43,7 @@ const TasksPage: React.FC = () => {
       </div>
       <div className="font-bold text-md mt-4 text-primary">참여 그룹원</div>
       <GroupMemberList members={members} />
+      <HistoryModal open={showHistory} onClose={() => setShowHistory(false)} items={historyItems} />
     </div>
   )
 }


### PR DESCRIPTION
### 작업
- 할일 페이지 초기 UI 구현.
- 그룹장 기준 화면으로 구현

### 주요 변경
- 주간 업무표 UI 추가
- 그룹원 리스트 UI 추가
- 요일 선택 모달 추가
- 버튼 컴포넌트 추가

### 체크리스트
- 요일 선택 모달 다중 선택 기능 구현
- UI만 구현