### PR TITLE
feat(utils):add formatPriceKRW

### DIFF
--- a/src/libs/utils/format.ts
+++ b/src/libs/utils/format.ts
@@ -5,6 +5,11 @@ export function formatCurrency(amount: number): string {
   }).format(amount)
 }
 
+export function formatPriceKRW(price: number): string {
+  const formatted = new Intl.NumberFormat('ko-KR').format(price)
+  return `${formatted}원`
+}
+
 export function formatDate(date: string | Date): string {
   return new Intl.DateTimeFormat('ko-KR', {
     year: 'numeric',


### PR DESCRIPTION
## Purpose
금액을 일관된 형식으로 표시하기 위한 유틸리티 함수를 추가

## Changes
- `utils/formatPrice.ts`
   - `formatPriceKRW`: 숫자를 천 단위 구분자(,)로 변환 후 원 단위를 붙여 반환 (예: 1,234,567원)

## Screenshots/GIF
해당 사항 없음 (UI 변경 없음)

## How to test
<!-- 테스트 방법을 설명해주세요 -->
1.` npm run dev` 실행
2. 콘솔 혹은 샘플 코드에서 아래 유틸 호출
   ```formatPriceKRW(1234567) // 1,234,567원
formatPriceKRW(10000)   // 10,000원
formatPriceKRW(500)     // 500원
```
3. 예상 출력과 일치하는지 확인

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다
- [x] `npm run typecheck`를 실행하여 타입 오류가 없습니다

