### PR TITLE
feat: 요일 반복 handler 구현

### DIFF
--- a/src/features/tasks/components/DaySelectModal.tsx
+++ b/src/features/tasks/components/DaySelectModal.tsx
@@ -1,74 +1,116 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { DaySelectModalProps, RepeatDay } from '../../../types/tasks'
+import { daysKr, toEngDay, KorDay } from '../../../libs/utils/dayMapping'
 
-interface DaySelectModalProps {
-  days: string[]
-  onClose: () => void
-  positionClass?: string
-}
+const DaySelectModal: React.FC<DaySelectModalProps> = ({
+  days = daysKr,
+  templateId,
+  onClose,
+  positionClass,
+}) => {
+  const [repeatDays, setRepeatDays] = useState<RepeatDay[]>([])
+  const [loading, setLoading] = useState(false)
 
-const DaySelectModal: React.FC<DaySelectModalProps> = ({ days, onClose, positionClass }) => {
-  const [checkedDays, setCheckedDays] = useState<string[]>([])
+  useEffect(() => {
+    const fetchRepeatDays = async () => {
+      setLoading(true)
+      const res = await axios.get<RepeatDay[]>(`/api/tasks/templates/${templateId}/repeat-days`)
+      setRepeatDays(res.data)
+      setLoading(false)
+    }
+    fetchRepeatDays()
+  }, [templateId])
 
-  const toggleDay = (day: string) => {
-    setCheckedDays((prev) => (prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day]))
+  const checkedDays = repeatDays.map((d) => d.dayOfWeek)
+
+  const toggleDay = async (dayKr: KorDay) => {
+    const dayEng = toEngDay(dayKr)
+    const exist = repeatDays.find((d) => d.dayOfWeek === dayEng)
+    if (!exist) {
+      const res = await axios.post<RepeatDay>(`/api/tasks/templates/${templateId}/repeat-days`, {
+        dayOfWeek: dayEng,
+      })
+      setRepeatDays((prev) => [...prev, res.data])
+    } else {
+      await axios.delete(`/api/tasks/templates/${templateId}/repeat-days/${exist.repeatDayId}`)
+      setRepeatDays((prev) => prev.filter((d) => d.repeatDayId !== exist.repeatDayId))
+    }
   }
 
   const allSelected = checkedDays.length === days.length
 
-  const handleToggleAll = () => {
-    if (allSelected) setCheckedDays([])
-    else setCheckedDays([...days])
-  }
-
-  const handleConfirm = () => {
-    onClose()
-  }
-
-  const handleCancel = () => {
-    onClose()
+  const handleToggleAll = async () => {
+    if (allSelected) {
+      await Promise.all(
+        repeatDays.map((d) =>
+          axios.delete(`/api/tasks/templates/${templateId}/repeat-days/${d.repeatDayId}`)
+        )
+      )
+      setRepeatDays([])
+    } else {
+      const notChecked = days.filter((day) => !checkedDays.includes(toEngDay(day)))
+      const responses = await Promise.all(
+        notChecked.map((day) =>
+          axios.post<RepeatDay>(`/api/tasks/templates/${templateId}/repeat-days`, {
+            dayOfWeek: toEngDay(day),
+          })
+        )
+      )
+      setRepeatDays([...repeatDays, ...responses.map((r) => r.data)])
+    }
   }
 
   return (
     <>
       <div className="fixed inset-0 z-40 bg-black/10" onClick={onClose} />
       <div
-        className={`z-50 bg-white shadow-lg rounded-xl border border-gray-200 w-40 absolute ${positionClass || ''}`}
+        className={`z-50 bg-white shadow-lg rounded-xl border border-gray-200 w-40 absolute ${
+          positionClass ?? ''
+        }`}
       >
         <div className="flex flex-col py-2">
-          <button type="button" className={`btn btn-sm mb-2 mx-3`} onClick={handleToggleAll}>
+          <button
+            type="button"
+            className="btn btn-sm mb-2 mx-3"
+            onClick={handleToggleAll}
+            disabled={loading}
+          >
             {allSelected ? '전체 해제' : '전체 선택'}
           </button>
 
           <div className="flex flex-col divide-y divide-gray-200">
-            {days.map((day) => (
+            {days.map((dayKr) => (
               <label
-                key={day}
+                key={dayKr}
                 className="flex items-center px-4 py-2 cursor-pointer hover:bg-gray-100"
               >
                 <input
                   type="checkbox"
                   className="checkbox checkbox-sm checkbox-primary"
-                  checked={checkedDays.includes(day)}
-                  onChange={() => toggleDay(day)}
+                  checked={checkedDays.includes(toEngDay(dayKr))}
+                  onChange={() => toggleDay(dayKr)}
+                  disabled={loading}
                 />
-                <span className="ml-2 text-sm font-medium">{day}</span>
+                <span className="ml-2 text-sm font-medium">{dayKr}</span>
               </label>
             ))}
           </div>
 
-          {/* 확인, 취소 */}
           <div className="flex justify-center space-x-2 mt-1 px-1 pt-2 pb-1 border-t border-gray-200">
             <button
               type="button"
               className="btn btn-sm min-w-[60px] btn-primary"
-              onClick={handleConfirm}
+              onClick={onClose}
+              disabled={loading}
             >
               확인
             </button>
             <button
               type="button"
               className="btn btn-sm min-w-[60px] btn-outline"
-              onClick={handleCancel}
+              onClick={onClose}
+              disabled={loading}
             >
               취소
             </button>

--- a/src/features/tasks/components/TaskTable.tsx
+++ b/src/features/tasks/components/TaskTable.tsx
@@ -2,20 +2,15 @@ import React, { useEffect, useState } from 'react'
 import DaySelectModal from './DaySelectModal'
 import { ChevronRight, PlusCircleFill } from 'react-bootstrap-icons'
 import axios from 'axios'
+import { Template } from '../../../types/tasks'
+import { daysKr } from '../../../libs/utils/dayMapping'
 
 const days = ['일', '월', '화', '수', '목', '금', '토']
 
-type Template = {
-  templateId: number
-  groupId: number
-  category: string
-  createdAt: string
-}
-
 const initialEmptyTemplates: Template[] = [
-  { templateId: -1, groupId: 1, category: '', createdAt: '' },
-  { templateId: -2, groupId: 1, category: '', createdAt: '' },
-  { templateId: -3, groupId: 1, category: '', createdAt: '' },
+  { templateId: -1, groupId: 1, category: '', createdAt: '', updatedAt: '' },
+  { templateId: -2, groupId: 1, category: '', createdAt: '', updatedAt: '' },
+  { templateId: -3, groupId: 1, category: '', createdAt: '', updatedAt: '' },
 ]
 
 const TaskTable: React.FC = () => {
@@ -140,7 +135,8 @@ const TaskTable: React.FC = () => {
                   </button>
                   {openModal === rowIdx && (
                     <DaySelectModal
-                      days={days}
+                      days={daysKr}
+                      templateId={template.templateId}
                       onClose={() => setOpenModal(null)}
                       positionClass="left-full -top-3 ml-1"
                     />

--- a/src/libs/utils/dayMapping.ts
+++ b/src/libs/utils/dayMapping.ts
@@ -1,0 +1,23 @@
+export const daysMap = {
+  일: 'SUNDAY',
+  월: 'MONDAY',
+  화: 'TUESDAY',
+  수: 'WEDNESDAY',
+  목: 'THURSDAY',
+  금: 'FRIDAY',
+  토: 'SATURDAY',
+} as const
+
+export type KorDay = keyof typeof daysMap
+
+export const daysKr: KorDay[] = ['일', '월', '화', '수', '목', '금', '토']
+
+export function toEngDay(korDay: KorDay): string {
+  return daysMap[korDay]
+}
+
+export function toKorDay(engDay: string): KorDay | undefined {
+  const entries = Object.entries(daysMap) as [KorDay, string][]
+  const found = entries.find(([, v]) => v === engDay)
+  return found ? found[0] : undefined
+}

--- a/src/mocks/db/tasks.ts
+++ b/src/mocks/db/tasks.ts
@@ -1,0 +1,25 @@
+import { RepeatDay, Template } from '../../types/tasks'
+
+export const templates: Template[] = [
+  { templateId: 1, groupId: 1, category: '청소', createdAt: '2025-08-05T10:00:00', updatedAt: '' },
+  {
+    templateId: 2,
+    groupId: 1,
+    category: '설거지',
+    createdAt: '2025-08-05T10:00:00',
+    updatedAt: '',
+  },
+  {
+    templateId: 3,
+    groupId: 1,
+    category: '분리수거',
+    createdAt: '2025-08-05T10:00:00',
+    updatedAt: '',
+  },
+]
+
+export const repeatDays: RepeatDay[] = [
+  { repeatDayId: 1, templateId: 1, dayOfWeek: 'MONDAY' },
+  { repeatDayId: 2, templateId: 2, dayOfWeek: 'THURSDAY' },
+  { repeatDayId: 3, templateId: 3, dayOfWeek: 'FRIDAY' },
+]

--- a/src/mocks/handlers/tasksHandlers.ts
+++ b/src/mocks/handlers/tasksHandlers.ts
@@ -1,4 +1,6 @@
 import { HttpResponse, http } from 'msw'
+import { templates, repeatDays } from '../db/tasks'
+import { RepeatDay, Template } from '../../types/tasks'
 
 /* ─────────────────────────────────────────────
    0) 엔드포인트
@@ -16,49 +18,76 @@ type TaskTemplateRequest = {
   category?: string
 }
 
-let templates = [
-  { templateId: 1, groupId: 1, category: '', createdAt: '' },
-  { templateId: 2, groupId: 1, category: '', createdAt: '' },
-  { templateId: 3, groupId: 1, category: '', createdAt: '' },
-]
+type RepeatDayRequest = {
+  dayOfWeek: string
+}
 
 export const tasksHandlers = [
+  // 할일 템플릿 목록 조회
   http.get('/tasks/templates', () => {
     return HttpResponse.json(templates, { status: 200 })
   }),
 
+  // 할일 템플릿 생성
   http.post('/tasks/templates', async ({ request }) => {
     let body: unknown = await request.json()
     if (typeof body !== 'object' || body === null) body = {}
     const { groupId = 0, category = '' } = body as TaskTemplateRequest
 
-    const newTemplate = {
+    const newTemplate: Template = {
       templateId: templates.length + 1,
       groupId,
       category,
-      createdAt: '2025-08-05T10:00:00',
+      createdAt: new Date().toISOString(),
+      updatedAt: '',
     }
     templates.push(newTemplate)
     return HttpResponse.json(newTemplate, { status: 200 })
   }),
 
+  // 할일 템플릿 수정
   http.put('/tasks/templates/:templateId', async ({ params, request }) => {
     const { templateId } = params
     let body: unknown = await request.json()
     if (typeof body !== 'object' || body === null) body = {}
     const { category } = body as TaskTemplateRequest
 
-    templates = templates.map((tpl) =>
-      String(tpl.templateId) === String(templateId)
-        ? {
-            ...tpl,
-            ...(category && { category }),
-            updatedAt: '2025-08-06T09:00:00',
-          }
-        : tpl
-    )
-
+    for (const tpl of templates) {
+      if (String(tpl.templateId) === String(templateId)) {
+        if (category) tpl.category = category
+        tpl.updatedAt = new Date().toISOString()
+      }
+    }
     const updated = templates.find((tpl) => String(tpl.templateId) === String(templateId))
     return HttpResponse.json(updated, { status: 200 })
+  }),
+
+  // 반복 요일 목록 조회
+  http.get('/api/tasks/templates/:templateId/repeat-days', ({ params }) => {
+    const { templateId } = params
+    const result = repeatDays.filter((d) => String(d.templateId) === String(templateId))
+    return HttpResponse.json(result, { status: 200 })
+  }),
+
+  // 반복 요일 추가
+  http.post('/api/tasks/templates/:templateId/repeat-days', async ({ params, request }) => {
+    const { templateId } = params
+    const body = (await request.json()) as RepeatDayRequest
+    const { dayOfWeek } = body
+    const newRepeatDay: RepeatDay = {
+      repeatDayId: repeatDays.length + 1,
+      templateId: Number(templateId),
+      dayOfWeek,
+    }
+    repeatDays.push(newRepeatDay)
+    return HttpResponse.json(newRepeatDay, { status: 200 })
+  }),
+
+  // 반복 요일 삭제
+  http.delete('/api/tasks/templates/:templateId/repeat-days/:repeatDayId', ({ params }) => {
+    const { repeatDayId } = params
+    const idx = repeatDays.findIndex((d) => String(d.repeatDayId) === String(repeatDayId))
+    if (idx !== -1) repeatDays.splice(idx, 1)
+    return new HttpResponse(null, { status: 204 })
   }),
 ]

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -1,0 +1,22 @@
+import { KorDay } from '../libs/utils/dayMapping'
+
+export interface Template {
+  templateId: number
+  groupId: number
+  category: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RepeatDay {
+  repeatDayId: number
+  templateId: number
+  dayOfWeek: string
+}
+
+export interface DaySelectModalProps {
+  days: KorDay[]
+  templateId: number
+  onClose: () => void
+  positionClass?: string
+}


### PR DESCRIPTION
## Purpose
msw 라이브러리 이용하여 요일 반복 handler 구현

## Changes
- tasks의 type 일부 분리 (다음 단계에서 전부 분리할 것)
- tasks의 db 분리
- 반복 요일 조회/추가/삭제 handler 구현
- 요일 한글 <-> 영어 Mapping util 추가

## Checklist
- [x] `npm run dev`를 실행하여 빌드가 성공합니다
