### PR TITLE
feat(mypage-alarm):알림 설정 모달 UI 및 TimePicker 드롭다운 구현

### DIFF
--- a/src/features/mypage/components/AlarmSettingModal.tsx
+++ b/src/features/mypage/components/AlarmSettingModal.tsx
@@ -1,6 +1,7 @@
 import { XCircle } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import Toggle from '../../common/Toggle'
+import AmPmTimePicker from './AmPmTimePicker'
 
 interface OnCloseProps {
   onClose: () => void
@@ -67,20 +68,20 @@ export default function AlarmSettingModal({ onClose }: OnCloseProps) {
               {/* 할 일 알림 */}
               <div
                 className={`shadow-md px-4 py-3 rounded-xl bg-base-200 transition-[height] duration-500 ease-in-out 
-                            ${taskToggleOn ? 'h-44' : ''}`}
+                            ${taskToggleOn ? 'h-40' : ''}`}
               >
-                <div className="flex justify-between">
+                <div className="flex justify-between mb-2">
                   <span>할 일 알림</span>
                   <Toggle checked={taskToggleOn} onChange={setTaskToggleOn} />
                 </div>
+
                 {taskToggleOn && (
-                  <div className="flex flex-col">
-                    <span>알림 시간 설정</span>
+                  <div className="flex flex-col gap-2 pl-2 pt-4">
+                    <span className="text-sm font-semibold">알림 시간 설정</span>
+                    <AmPmTimePicker />
                   </div>
                 )}
               </div>
-
-              {taskToggleOn && <div></div>}
 
               {/* 공지사항 알림 */}
               <div className="flex justify-between items-center shadow-md px-4 py-3 rounded-xl bg-base-200">

--- a/src/features/mypage/components/AmPmTimePicker.tsx
+++ b/src/features/mypage/components/AmPmTimePicker.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import ScrollDropDown from './ScrollDropdown'
+
+export default function AmPmTimePicker() {
+  const [ampm, setAmpm] = useState<'AM' | 'PM'>('AM')
+  const [hour, setHour] = useState<number>(8)
+  const [minute, setMinute] = useState<number>(0)
+
+  // 각 드롭다운 열림 상태
+  const [showAmpm, setShowAmpm] = useState(false)
+  const [showHour, setShowHour] = useState(false)
+  const [showMinute, setShowMinute] = useState(false)
+
+  const ampmRef = useRef<HTMLDivElement>(null)
+  const hourRef = useRef<HTMLDivElement>(null)
+  const minuteRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        ampmRef.current &&
+        !ampmRef.current.contains(e.target as Node) &&
+        hourRef.current &&
+        !hourRef.current.contains(e.target as Node) &&
+        minuteRef.current &&
+        !minuteRef.current.contains(e.target as Node)
+      ) {
+        setShowAmpm(false)
+        setShowHour(false)
+        setShowMinute(false)
+      }
+    }
+
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowAmpm(false)
+        setShowHour(false)
+        setShowMinute(false)
+      }
+    }
+
+    document.addEventListener('click', handleClickOutside)
+    document.addEventListener('keydown', handleEsc)
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [])
+
+  const ampmItems = useMemo(
+    () => [
+      { value: 'AM', label: '오전' },
+      { value: 'PM', label: '오후' },
+    ],
+    []
+  )
+  const hourItems = useMemo(
+    () => Array.from({ length: 12 }, (_, i) => i + 1).map((h) => ({ value: h, label: String(h) })),
+    []
+  )
+  const minuteItems = useMemo(
+    () =>
+      Array.from({ length: 60 }, (_, i) => i).map((m) => ({
+        value: m,
+        label: String(m).padStart(2, '0'),
+      })),
+    []
+  )
+
+  return (
+    <div>
+      <div className="flex rounded-lg justify-start items-center gap-3">
+        {/* 오전/오후 */}
+        <div ref={ampmRef}>
+          <ScrollDropDown
+            open={showAmpm}
+            onOpenChange={(v) => {
+              setShowAmpm(v)
+              if (v) {
+                setShowHour(false)
+                setShowMinute(false)
+              }
+            }}
+            items={ampmItems}
+            value={ampm}
+            onChange={(v) => setAmpm(v as 'AM' | 'PM')}
+          />
+        </div>
+        {/* 시 선택 */}
+        <div className="flex justify-center items-end gap-1" ref={hourRef}>
+          <ScrollDropDown
+            open={showHour}
+            onOpenChange={(v) => {
+              setShowHour(v)
+              if (v) {
+                setShowAmpm(false)
+                setShowMinute(false)
+              }
+            }}
+            items={hourItems}
+            value={hour}
+            onChange={(v) => setHour(v as number)}
+          />
+          <span className="text-xs mb-1">시</span>
+        </div>
+        {/* 분 선택 */}
+        <div className="flex justify-center items-end gap-1" ref={minuteRef}>
+          <ScrollDropDown
+            open={showMinute}
+            onOpenChange={(v) => {
+              setShowMinute(v)
+              if (v) {
+                setShowAmpm(false)
+                setShowHour(false)
+              }
+            }}
+            items={minuteItems}
+            value={minute}
+            onChange={(v) => setMinute(v as number)}
+          />
+          <span className="text-xs mb-1">분</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/mypage/components/ScrollDropdown.tsx
+++ b/src/features/mypage/components/ScrollDropdown.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react'
+
+type Option = { value: string | number; label: string }
+
+type ScrollDropDownProps = {
+  items: Option[]
+  value: string | number
+  onChange: (v: string | number) => void
+  open: boolean
+  onOpenChange: (v: boolean) => void
+}
+
+export default function ScrollDropDown({
+  open,
+  onOpenChange,
+  items,
+  value,
+  onChange,
+}: ScrollDropDownProps) {
+  const label = useMemo(() => items.find((it) => it.value === value)?.label ?? '', [items, value])
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => onOpenChange(!open)}
+        className="
+                  relative h-9 w-[4rem]
+                  grid grid-cols-[1rem_1fr_1rem] items-center
+                  border rounded-lg bg-white text-sm"
+      >
+        <span aria-hidden className="w-4" />
+        <span className="justify-self-center">{label}</span>
+      </button>
+
+      {/* 드롭다운 리스트 */}
+      {open && (
+        <div
+          role="listbox"
+          className="absolute top-full left-0 border rounded-lg w-full max-h-[10rem] overflow-y-auto px-1 py-1 gap-2 mt-1 text-sm bg-white shadow z-[9999] "
+        >
+          {items.map((item) => {
+            const selected = String(item.value) === String(value)
+            return (
+              <div
+                key={String(item.value)}
+                role="option"
+                aria-selected={selected}
+                onClick={(e) => {
+                  // 바깥 mousedown 닫힘보다 먼저 실행되어 선택/닫기
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onChange(item.value)
+                  onOpenChange(false) // 선택 직후 닫기
+                }}
+                className={[
+                  'px-3 py-2 cursor-pointer select-none rounded-lg text-center',
+                  selected ? 'bg-gray-100 font-semibold text-gray-900' : 'text-gray-700',
+                  'hover:bg-gray-50',
+                ].join(' ')}
+              >
+                <span>{item.label}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Purpose
- 알림 설정 모달 UI와 시간 선택 컴포넌트(UI 전용)를 추가
- 아직 상태관리(Zustand) 및 API 연동은 포함되지 않고, UI 구조/동작만 구현된 상태

## Changes
- `AlarmSettingModal `컴포넌트 추가
  - 전체 알림, 정산 알림, 할 일 알림, 공지사항 알림 토글 UI
- `AmPmTimePicker` 컴포넌트 추가
  - AM/PM, 시, 분 선택 가능한 커스텀 드롭다운 구현
- `ScrollDropDown` 공용 컴포넌트 추가
  - 선택 리스트 UI 및 외부 클릭/ESC 닫기 처리
  
## Screenshots/GIF
변경사항 없음

## How to test
<!-- 테스트 방법을 설명해주세요 -->
1. 앱 실행 후 알림 설정 모달 열기
2. 전체/개별 토글이 정상적으로 on/off 되는지 확인
3. 할 일 알림 켰을 때 시간 선택 드롭다운이 정상적으로 열리고 닫히는지 확인
4. 저장 버튼은 동작 없음(UI만 확인)

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다
- [x] `npm run typecheck`를 실행하여 타입 오류가 없습니다

