### PR TITLE
refactor: 초기 렌더 전에 worker 실행하도록 변경하여 Mock API 안정성 확보

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+// main.tsx (최소 수정판)
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -9,40 +10,36 @@ import { SplashScreen } from '@capacitor/splash-screen'
 import App from './App.tsx'
 import './styles/globals.css'
 
-// Define a more specific type for the window object with Capacitor
 interface WindowWithCapacitor extends Window {
-  Capacitor?: {
-    isNative: boolean
-  }
+  Capacitor?: { isNative: boolean }
 }
 
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      retry: 1,
-    },
+    queries: { staleTime: 5 * 60 * 1000, retry: 1 },
   },
 })
 
-// Initialize Capacitor app
+// [추가] DEV에서만 렌더 전에 MSW 먼저 시작
+async function enableMocking() {
+  if (!import.meta.env.DEV) return
+  const { worker } = await import('./mocks/browser')
+  await worker.start({
+    serviceWorker: { url: '/mockServiceWorker.js' },
+    onUnhandledRequest: 'bypass',
+  })
+}
+
+// 기존 Capacitor 초기화는 그대로
 const initializeApp = async () => {
   try {
-    // Check if running in Capacitor environment by trying to access native features
     const isCapacitor = !!(window as WindowWithCapacitor).Capacitor?.isNative
-
     if (isCapacitor) {
-      // Set status bar style
       await StatusBar.setStyle({ style: Style.Dark })
-
-      // Hide splash screen after app is ready
       await SplashScreen.hide()
-
-      // Handle app state changes
       CapApp.addListener('appStateChange', ({ isActive }) => {
         console.log('App state changed. Is active?', isActive)
       })
-
       CapApp.addListener('appUrlOpen', (data) => {
         console.log('App opened with URL:', data.url)
       })
@@ -54,26 +51,22 @@ const initializeApp = async () => {
   }
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-        <Toaster position="top-right" />
-      </BrowserRouter>
-    </QueryClientProvider>
-  </React.StrictMode>
-)
+// [변경] 부트스트랩 순서만 살짝 조정: MSW → 렌더 → Capacitor
+async function bootstrap() {
+  await enableMocking() // ← 여기서 MSW가 먼저 켜짐
 
-// Initialize app after render
-initializeApp()
-
-// DEV일 때만 MSW 시작
-if (import.meta.env.DEV) {
-  import('./mocks/browser').then(({ worker }) =>
-    worker.start({
-      serviceWorker: { url: '/mockServiceWorker.js' },
-      onUnhandledRequest: 'bypass',
-    })
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+          <Toaster position="top-right" />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </React.StrictMode>
   )
+
+  initializeApp()
 }
+
+bootstrap()


### PR DESCRIPTION
## Purpose
- MSW(Mock Service Worker)가 첫 렌더 시점에 안정적으로 동작하지 않는 문제를 개선하기 위함
- 렌더 이후에 worker를 시작하면 초기 API 호출이 실제 네트워크로 나가는 경우가 있어 이를 방지하고자 worker를 렌더 이전에 실행하도록 리팩터링

## Changes
- MSW `worker.start()` 실행 시점을 **ReactDOM.render 이전**으로 이동
- 기존 하단 `if (import.meta.env.DEV) ...` 블록 제거 (중복 실행 방지)
- 부트스트랩 함수(`bootstrap`) 내에서 `enableMocking()` → React 렌더 → Capacitor 초기화 순서로 변경

## Screenshots/GIF
(해당 없음 — UI 변경 없음)

## How to test
1. `npm run dev` 실행 후 콘솔 로그에서 **[MSW] Mocking enabled** 메시지가 출력되는지 확인
2. 브라우저 콘솔에서 `fetch('/api/health')` 호출 시 정상 응답이 오는지 확인 (테스트용 핸들러 있을 경우)
3. 앱 첫 진입 시 settlement API 요청이 모두 MSW를 통해 처리되는지 확인 (네트워크 탭 → Service Worker 표시 확인)

## Checklist
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다
- [x] `npm run typecheck`를 실행하여 타입 오류가 없습니다

