### PR TITLE
feat: 공통 로딩 컴포넌트 LoadingSpinner 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,12 @@
 import { Suspense } from 'react'
 import { Routes } from './app/routes'
 import AppLayout from './layouts/AppLayout'
+import LoadingSpinner from './features/common/LoadingSpinner'
 
 function App() {
   return (
     <AppLayout>
-      <Suspense fallback={
-        <div className="flex justify-center items-center h-64">
-          <span className="loading loading-spinner loading-lg"></span>
-        </div>
-      }>
+      <Suspense fallback={<LoadingSpinner />}>
         <Routes />
       </Suspense>
     </AppLayout>

--- a/src/features/common/LoadingSpinner.tsx
+++ b/src/features/common/LoadingSpinner.tsx
@@ -1,0 +1,7 @@
+export default function LoadingSpinner() {
+  return (
+    <div className="flex justify-center items-center h-64">
+      <span className="loading loading-spinner loading-lg"></span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Purpose
- 프로젝트 전역에서 일관된 로딩 UI를 제공하기 위해 **공통 로딩 컴포넌트(LoadingSpinner)**를 추가
- Suspense fallback 및 React Query 로딩 상태 등에서 재사용 가능하도록 만들었습니다.

## Changes
- `features/common/LoadingSpinner.tsx` 생성
  - 중앙 정렬 + spinner UI 공통화
- Suspense fallback에 `LoadingSpinner` 적용 (필요 시 다른 컴포넌트에서도 사용 가능)

## Screenshots/GIF
변경 사항 없음

## How to test
1. 로컬 서버 실행 (`npm run dev`)
2. 라우트 전환 시 Suspense fallback으로 로딩 스피너가 정상 출력되는지 확인
3. API 호출이 느린 컴포넌트에서 `isLoading` 상태일 때 스피너가 표시되는지 확인

## Checklist
- [ ] 코드 리뷰를 받았습니다
- [ ] `npm run lint` 실행 시 오류가 없습니다

