### PR TITLE
Feature/settlement msw connect

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,7 @@
+# 개발 중 MSW를 켜고 싶을 때 true
+# “실서버 개발 모드”로 확인하고 싶으면 VITE_USE_MSW=false 로 바꾸고 Vite dev 서버를 재시작
+VITE_USE_MSW=true
+
+# 개발에서 실제 백엔드로 붙일 때 프록시 타겟
+VITE_API_BASE_URL=http://localhost:4000
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "prettier": "^3.0.3",
         "tailwindcss": "^3.3.5",
         "typescript": "^5.2.2",
-        "vite": "^4.5.0"
+        "vite": "^4.5.14"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prettier": "^3.0.3",
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2",
-    "vite": "^4.5.0"
+    "vite": "^4.5.14"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/features/payments/components/paymentsListItem.tsx
+++ b/src/features/payments/components/paymentsListItem.tsx
@@ -1,76 +1,54 @@
 // src/features/settlements/components/SettlementListItem.tsx
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { ThreeDotsVertical, ChevronCompactDown } from 'react-bootstrap-icons'
 import settlementIcon from '../../../assets/icons/settlementIcon.svg'
 
-import { formatDateWithWeekday, formatPriceKRW } from '../../../libs/utils/format'
+import { formatDateTime, formatPriceKRW } from '../../../libs/utils/format'
 
-import type { Settlement } from '../../../types/settlement'
+import type { PaymentHistoryItem, Settlement, TransferStatus } from '../../../types/settlement'
 
-import {
-  usePaySettlement,
-  useCancelSettlement,
-} from '../../../libs/hooks/settlements/useSettlementMutations'
 import { fromCategory } from '../../../libs/utils/categoryMapping'
+import { fromTransferStatus } from '../../../libs/utils/statusMapping'
 
-type SettlementListItemProps = {
-  item: Settlement
-  viewerId: number
+type PaymentHistoryItemProps = {
+  item: PaymentHistoryItem
+  settlement?: Settlement
 }
 
-export default function SettlementListItem({ item, viewerId }: SettlementListItemProps) {
+// 상태별 배지 색상
+const STATUS_COLOR: Record<TransferStatus, string> = {
+  PENDING: '#ffd15e',
+  PAID: '#757575',
+  REFUNDED: '#C6ADD5',
+  FAILED: '#CE6B6B',
+  CANCELED: '#CE6B6B',
+}
+
+export default function PaymentsListItem({ item, settlement }: PaymentHistoryItemProps) {
   if (!item) return null
 
   const [cardOpen, SetCardOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
 
-  const payMut = usePaySettlement()
-  const cancelMut = useCancelSettlement()
-
-  const settlement = item
-  const isPayer = settlement.payerId === viewerId
-  const me = settlement.participants.find((p) => p.memberId === viewerId)
-  const myDue = me?.shareAmount ?? 0
-  const isMyPaymentDone = me?.status === 'PAID'
-  const isPendingSettlement = settlement.status === 'PENDING'
-
-  const handlePayClick = () => {
-    if (isPayer) return
-    if (!isPendingSettlement) return
-    if (isMyPaymentDone) return
-    if (payMut.isPending) return
-    payMut.mutate(settlement.id)
-  }
-
-  const handleCancelClick = () => {
-    if (!isPayer) return
-    if (!isPendingSettlement) return
-    if (cancelMut.isPending) return
-    cancelMut.mutate(settlement.id)
-  }
-
-  let pill: { text: string; bg: string }
-  if (settlement.status === 'COMPLETED') {
-    pill = { text: '정산 완료', bg: '#B3B3B3' }
-  } else if (isPayer && isPendingSettlement) {
-    pill = { text: '진행 중', bg: '#ffd877' }
-  } else if (settlement.status === 'CANCELED') {
-    pill = { text: '정산 취소', bg: '#C6ADD5' }
-  } else if (isMyPaymentDone) {
-    pill = { text: '송금 완료', bg: '#B3B3B3' }
-  } else {
-    pill = { text: '송금하기', bg: '#d26c6c' }
-  }
+  // 배지 텍스트/색
+  const pill = useMemo(
+    () => ({
+      text: fromTransferStatus(item.status), // 'PAID' → '송금 완료'
+      bg: STATUS_COLOR[item.status] ?? '#ffd15e',
+    }),
+    [item.status]
+  )
 
   return (
     <div
       className={`flex flex-col border-2 border-gray-100 bg-gray-50 rounded-xl pl-4 pr-1 py-3 shadow-md
                         overflow-hidden transition-[max-height] duration-500 ease-in-out 
-                        ${cardOpen ? 'max-h-screen' : isPayer ? 'max-h-40' : 'max-h-44'}`}
+                        ${cardOpen ? 'max-h-screen' : 'max-h-44'}`}
     >
       {/* 요약 카드 */}
       <div className="flex justify-between items-center mb-2">
-        <span className="text-sm">{formatDateWithWeekday(settlement.createdAt)}</span>
+        {/* 상단 */}
+        <span className="text-sm">{formatDateTime(item.transferAt)}</span>
         <div className="relative ">
           <button
             onClick={(e) => {
@@ -85,46 +63,34 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
             className={`flex flex-col border border-neutral-400 rounded-lg shadow-md items-center justify-center absolute right-0 w-28 h-fit bg-white p-2 ${menuOpen ? 'opacity-100' : 'max-h-0 opacity-0'}`}
           >
             <button className="py-1 text-sm">정산 상세</button>
-            <div className="border-t w-full"></div>
-            <button
-              className="py-1 text-sm"
-              onClick={handleCancelClick}
-              disabled={cancelMut.isPending}
-            >
-              {cancelMut.isPending ? '취소 중…' : '정산 취소'}
-            </button>
           </div>
         </div>
       </div>
 
+      {/* 본문 */}
       <div className="flex justify-between items-center">
         <div className="flex flex-col gap-2">
           <div className="flex gap-2 items-center">
             <span className="border border-neutral-400 rounded-xl w-fit h-5 px-1 text-cent text-gray-500 text-xs text-center">
-              {fromCategory(settlement.category)}
+              {fromCategory(settlement?.category ?? 'ETC')}
             </span>
-            <span className="font-bold text-base">{settlement.title}</span>
+            <span className="font-bold text-base">{settlement?.title}</span>
           </div>
           <div className="flex flex-col pl-1 gap-1">
-            <span className="text-sm">금액: {formatPriceKRW(settlement.settlementAmount)}</span>
+            <span className="text-sm">송금 금액: {formatPriceKRW(item.amount)}</span>
             <span
               className={`block overflow-hidden text-sm transition-[max-height, opacity] duration-500 ease-in-out ${cardOpen ? 'opacity-0' : 'opacity-100 delay-300 max-h-10'}`}
             >
-              참여자 {settlement.participants.length}명
+              참여자 {settlement?.participants.length}명
             </span>
-            {!isPayer && (
-              <span className="text-base font-bold mb-1">송금 금액 : {formatPriceKRW(myDue)}</span>
-            )}
           </div>
         </div>
 
         <div
           className={`flex justify-center items-center transition-[opacity, max-height] duration-200 ${cardOpen ? 'max-h-0 max-w-0 opacity-0 overflow-hidden' : 'h-8 w-20 opacity-100'} rounded-badge text-sm text-white font-bold mr-3`}
           style={{ backgroundColor: pill.bg }}
-          onClick={handlePayClick}
-          aria-disabled={isPayer || isMyPaymentDone || !isPendingSettlement || payMut.isPending}
         >
-          {payMut.isPending ? '처리 중…' : pill.text}
+          {pill.text}
         </div>
       </div>
 
@@ -134,9 +100,9 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
       >
         <div className="flex flex-col gap-2">
           <div className="text-sm ml-1 w-fit bg-[linear-gradient(transparent_65%,#fde68a_0)]">
-            결제자: {settlement.payerName}
+            결제자: {settlement?.payerName}
           </div>
-          {settlement.participants
+          {settlement?.participants
             .filter((p) => p.memberId !== settlement.payerId)
             .map((p) => {
               const badge =

--- a/src/features/settlements/components/OngoingSettlements.tsx
+++ b/src/features/settlements/components/OngoingSettlements.tsx
@@ -1,36 +1,42 @@
+import LoadingSpinner from '../../common/LoadingSpinner'
 import SettlementListItem from './SettlementListItem'
+import { useMySettlements } from '../../../libs/hooks/settlements/useMySettlements'
 
 export default function OngoingSettlements() {
-  return (
-    // 데이터가 없을 경우 UI
-    // <section className="card border-2 border-dashed bg-base-200 shadow-sm">
-    //   <div className="card-body p-4">
-    //     <div className="flex justify-between items-center">
-    //       <h2 className="card-title text-xl text-[oklch(44%_0.043_257.281)]">진행 중인 정산</h2>
-    //       <button>
-    //         <ThreeDotsVertical size={20} />
-    //       </button>
-    //     </div>
-    //     <div className="flex flex-col justify-center text-center mt-4">
-    //       <img
-    //         src={'/src/assets/icons/settlementIcon.svg'}
-    //         alt="empty icon"
-    //         className="h-10 w-10 mx-auto"
-    //       />
-    //       <p className="text-sm font-medium text-neutral-400 text-center p-3">
-    //         진행 중인 정산이 없어요
-    //       </p>
-    //     </div>
-    //   </div>
-    // </section>
+  const { data, isLoading, error } = useMySettlements()
 
-    // 데이터가 있을 경우 UI
-    <section className="card">
-      <div className="card-body p-4 bg-base-200 shadow rounded-xl">
+  if (isLoading) return <LoadingSpinner />
+  if (error) return <p className="text-sm text-error">에러가 발생했어요</p>
+
+  const ongoing = (data ?? []).filter((s) => s.status === 'PENDING')
+  const isEmpty = ongoing.length === 0
+
+  return (
+    <section className={`card ${isEmpty ? 'border-2 border-dashed bg-base-200 shadow-sm' : ''}`}>
+      <div
+        className={`${isEmpty ? 'card-body p-4' : 'card-body p-4 bg-base-200 shadow rounded-xl'}`}
+      >
         <div className="flex justify-between items-center">
           <h2 className="card-title text-xl text-[oklch(44%_0.043_257.281)]">진행 중인 정산</h2>
         </div>
-        <SettlementListItem />
+        {isEmpty ? (
+          <div className="flex flex-col justify-center text-center mt-4">
+            <img
+              src="/src/assets/icons/settlementIcon.svg"
+              alt="empty icon"
+              className="h-10 w-10 mx-auto"
+            />
+            <p className="text-sm font-medium text-neutral-400 text-center p-3">
+              진행 중인 정산이 없어요
+            </p>
+          </div>
+        ) : (
+          <>
+            {ongoing.map((s) => (
+              <SettlementListItem key={s.id} item={s} viewerId={1} />
+            ))}
+          </>
+        )}
       </div>
     </section>
   )

--- a/src/features/settlements/components/RecentSettlements.tsx
+++ b/src/features/settlements/components/RecentSettlements.tsx
@@ -1,30 +1,32 @@
 import { Link } from 'react-router-dom'
 import SettlementListItem from './SettlementListItem'
+import { useMySettlements } from '../../../libs/hooks/settlements/useMySettlements'
+import LoadingSpinner from '../../common/LoadingSpinner'
 
 export default function RecentSettlements() {
+  const { data, isLoading, error } = useMySettlements()
+
+  if (isLoading) return <LoadingSpinner />
+  if (error) return <p className="text-sm text-error">에러가 발생했어요</p>
+
+  // 완료된 정산
+  const completed = (data ?? []).filter((s) => s.status === 'COMPLETED')
+
+  // 최신순 정렬
+  const sorted = completed.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
+
+  // 최근 2개
+  const recent2 = sorted.slice(0, 2)
+
+  const isEmpty = completed.length === 0
+
   return (
-    // 데이터가 없을 경우
-    // <section className="card border-2 border-dashed bg-base-200 shadow-sm">
-    //   <div className="card-body p-4">
-    //     <div className="flex items-baseline gap-1 text-center">
-    //       <h2 className="card-title text-success">정산 내역</h2>
-    //       <span className="text-[0.7rem] text-neutral-400">(최근 내역 2개)</span>
-    //     </div>
-
-    //     <div className="flex flex-col justify-center text-center mt-4">
-    //       <img
-    //         src="/src/assets/icons/settlementIcon.svg"
-    //         alt="empty icon"
-    //         className="h-10 w-10 mx-auto"
-    //       />
-    //       <p className="text-sm font-medium text-neutral-400 text-center p-3">정산 내역이 없어요</p>
-    //     </div>
-    //   </div>
-    // </section>
-
-    // 데이터가 있을 경우
-    <section className="card">
-      <div className="card-body p-4 bg-base-200 shadow rounded-xl">
+    <section className={`card ${isEmpty ? 'border-2 border-dashed bg-base-200 shadow-sm' : ''}`}>
+      <div
+        className={`${isEmpty ? 'card-body p-4' : 'card-body p-4 bg-base-200 shadow rounded-xl'}`}
+      >
         <div className="flex items-baseline gap-1 text-center">
           <h2 className="card-title text-success">정산 내역</h2>
           <div className="flex flex-1 justify-between">
@@ -35,8 +37,24 @@ export default function RecentSettlements() {
           </div>
         </div>
 
-        {/* 리스트 */}
-        <SettlementListItem />
+        {isEmpty ? (
+          <div className="flex flex-col justify-center text-center mt-4">
+            <img
+              src="/src/assets/icons/settlementIcon.svg"
+              alt="empty icon"
+              className="h-10 w-10 mx-auto"
+            />
+            <p className="text-sm font-medium text-neutral-400 text-center p-3">
+              정산 내역이 없어요
+            </p>
+          </div>
+        ) : (
+          <>
+            {recent2.map((s) => (
+              <SettlementListItem key={s.id} item={s} viewerId={1} />
+            ))}
+          </>
+        )}
       </div>
     </section>
   )

--- a/src/libs/api/axios.ts
+++ b/src/libs/api/axios.ts
@@ -1,11 +1,19 @@
 import axios from 'axios'
 
+const isMock = import.meta.env.DEV && import.meta.env.VITE_USE_MSW === 'true'
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000',
+  baseURL: isMock
+    ? '/api' // DEV + MSW일 때는 /api (상대경로)로 통일 → MSW가 잡음
+    : import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000',
   timeout: 10000,
-  headers: {
-    'Content-Type': 'application/json',
-  },
+  headers: { 'Content-Type': 'application/json' },
+})
+
+// ★ 디버깅 로그: 최종 요청이 뭔지 무조건 찍자
+api.interceptors.request.use((c) => {
+  console.log('[REQ]', c.baseURL, c.url) // 예: /api  /settlements/my
+  return c
 })
 
 // Request interceptor - attach auth token

--- a/src/libs/api/endpoints.ts
+++ b/src/libs/api/endpoints.ts
@@ -8,11 +8,30 @@ export const AUTH_ENDPOINTS = {
 
 // Settlements endpoints
 export const SETTLEMENTS_ENDPOINTS = {
-  LIST: '/settlements',
-  CREATE: '/settlements',
-  DETAIL: (id: string) => `/settlements/${id}`,
-  UPDATE: (id: string) => `/settlements/${id}`,
-  DELETE: (id: string) => `/settlements/${id}`,
+  // 목록
+  MY_LIST: '/settlements/my', // 내가 속한 정산 목록
+  GROUP_LIST: (groupId: number) => `/settlements/group/${groupId}`, // 그룹 정산 목록(그룹장)
+
+  // 생성 & 기본 CRUD
+  CREATE: '/settlements', // POST 정산 생성
+  DETAIL: (id: number) => `/settlements/${id}`, // GET 정산 상세
+  DELETE: (id: number) => `/settlements/${id}`, // DELETE 정산 취소
+
+  // 참여자 / 상태 변경
+  PARTICIPANTS: (id: number) => `/settlements/${id}/participants`, // 참여자 목록
+  PAYMENT_DONE: (id: number) => `/settlements/${id}/payment`, // 송금 완료 처리
+
+  // 히스토리
+  MY_HISTORY: '/settlements/my/history', // 나의 정산 히스토리
+  PAYMENT_HISTORIES: '/payments/histories', // 나의 송금 히스토리
+
+  // 영수증
+  RECEIPT: (id: number) => `/settlements/${id}/receipt`, // POST/PUT/DELETE 영수증
+} as const
+
+// 멤버 (보조 API)
+export const MEMBERS_ENDPOINT = {
+  LIST: '/members',
 } as const
 
 // Tasks endpoints

--- a/src/libs/api/payments.ts
+++ b/src/libs/api/payments.ts
@@ -1,0 +1,9 @@
+import axios from './axios'
+import type { PaymentHistoryItem } from '../../types/settlement'
+import { SETTLEMENTS_ENDPOINTS } from './endpoints'
+
+// 내 송금 내역 가져오기
+export async function fetchMyPayments(): Promise<PaymentHistoryItem[]> {
+  const { data } = await axios.get(SETTLEMENTS_ENDPOINTS.PAYMENT_HISTORIES)
+  return Array.isArray(data) ? data : (data?.content ?? [])
+}

--- a/src/libs/api/settlements.ts
+++ b/src/libs/api/settlements.ts
@@ -1,0 +1,22 @@
+import axios from './axios'
+import type { Settlement } from '../../types/settlement'
+import { SETTLEMENTS_ENDPOINTS } from './endpoints'
+
+// 내 정산 내역 가져오기
+export async function fetchMySettlements(): Promise<Settlement[]> {
+  const { data } = await axios.get<Settlement[]>(SETTLEMENTS_ENDPOINTS.MY_LIST)
+  return data
+}
+
+// 정산 히스토리
+export async function fetchMySettlementHistory(): Promise<Settlement[]> {
+  const { data } = await axios.get(SETTLEMENTS_ENDPOINTS.MY_HISTORY)
+  return Array.isArray(data) ? data : (data?.content ?? [])
+}
+
+// 송금하기
+export const postPaymentDone = (id: number) =>
+  axios.post<Settlement>(SETTLEMENTS_ENDPOINTS.PAYMENT_DONE(id)).then((r) => r.data)
+
+// 정산 취소
+export const cancelSettlement = (id: number) => axios.delete(SETTLEMENTS_ENDPOINTS.DELETE(id))

--- a/src/libs/hooks/settlements/useMyPayments.ts
+++ b/src/libs/hooks/settlements/useMyPayments.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchMyPayments } from '../../api/payments'
+import { PaymentHistoryItem } from '../../../types/settlement'
+
+export function useMyPayments() {
+  return useQuery<PaymentHistoryItem[]>({
+    queryKey: ['payments', 'histories'],
+    queryFn: fetchMyPayments,
+    staleTime: 30000,
+  })
+}

--- a/src/libs/hooks/settlements/useMySettlements.ts
+++ b/src/libs/hooks/settlements/useMySettlements.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import { Settlement } from '../../../types/settlement'
+import { fetchMySettlementHistory, fetchMySettlements } from '../../api/settlements'
+
+export function useMySettlements() {
+  return useQuery<Settlement[]>({
+    queryKey: ['settlements', 'my'],
+    queryFn: fetchMySettlements,
+    staleTime: 30000,
+  })
+}
+
+export function useMySettlementHistory() {
+  return useQuery({
+    queryKey: ['settlements', 'myHistory'],
+    queryFn: fetchMySettlementHistory,
+    staleTime: 30000,
+  })
+}

--- a/src/libs/hooks/settlements/useSettlementMutations.ts
+++ b/src/libs/hooks/settlements/useSettlementMutations.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { postPaymentDone, cancelSettlement } from '../../api/settlements'
+
+// 송금 완료
+export function usePaySettlement() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => postPaymentDone(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['settlements', 'my'] })
+    },
+  })
+}
+
+// 정산 취소
+export function useCancelSettlement() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => cancelSettlement(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['settlements', 'my'] })
+    },
+  })
+}

--- a/src/libs/utils/categoryMapping.ts
+++ b/src/libs/utils/categoryMapping.ts
@@ -1,0 +1,23 @@
+import { SettlementCategory } from '../../types/settlement'
+
+// 카테고리 변환 함수
+export function fromCategory(category: SettlementCategory): string {
+  const map: Record<SettlementCategory, string> = {
+    FOOD: '식비',
+    DAILY_SUPPLIES: '생활용품',
+    CULTURE: '문화생활',
+    ETC: '기타',
+  }
+  return map[category] ?? '기타'
+}
+
+export function toCategory(input: string): SettlementCategory {
+  const map: Record<string, SettlementCategory> = {
+    식비: 'FOOD',
+    식사: 'FOOD',
+    생활용품: 'DAILY_SUPPLIES',
+    문화생활: 'CULTURE',
+    기타: 'ETC',
+  }
+  return map[input] ?? 'ETC'
+}

--- a/src/libs/utils/statusMapping.ts
+++ b/src/libs/utils/statusMapping.ts
@@ -1,0 +1,24 @@
+import { TransferStatus } from '../../types/settlement'
+
+// 코드 → 라벨
+export function fromTransferStatus(status: TransferStatus): string {
+  const map: Record<TransferStatus, string> = {
+    PENDING: '송금 대기',
+    PAID: '송금 완료',
+    REFUNDED: '송금 취소',
+    FAILED: '송금 실패',
+    CANCELED: '송금 전 취소',
+  }
+  return map[status] ?? '송금 대기'
+}
+
+// 라벨 → 코드
+export function toTransferStatus(input: string): TransferStatus {
+  const map: Record<string, TransferStatus> = {
+    '송금 대기': 'PENDING',
+    '송금 완료': 'PAID',
+    '송금 취소': 'REFUNDED',
+    '송금 실패': 'FAILED',
+  }
+  return map[input] ?? 'PENDING'
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,7 +22,8 @@ const queryClient = new QueryClient({
 
 // [추가] DEV에서만 렌더 전에 MSW 먼저 시작
 async function enableMocking() {
-  if (!import.meta.env.DEV) return
+  if (!import.meta.env.DEV || import.meta.env.MODE !== 'development') return
+
   const { worker } = await import('./mocks/browser')
   await worker.start({
     serviceWorker: { url: '/mockServiceWorker.js' },

--- a/src/mocks/db/settlement.ts
+++ b/src/mocks/db/settlement.ts
@@ -33,6 +33,29 @@ export function toCategory(input: string): SettlementCategory {
    ───────────────────────────────────────────── */
 export const settlements: Settlement[] = [
   {
+    id: 9,
+    category: 'FOOD',
+    title: '마라탕 배달비4',
+    description: '저녁 식사 비용',
+    settlementAmount: 44500,
+    status: 'COMPLETED',
+    imageUrl:
+      'https://cohouse-bucket.s3.ap-northeast-2.amazonaws.com/groups/1/settlements/8/receipt/0e8d76d5-756b-4221-9d7a-d59ec184a283_pizza.jpg',
+    payerId: 2,
+    payerName: members[1].name,
+    platformSupportAmount: 0,
+    equalDistribution: true,
+    participants: [
+      { id: 30, memberId: 1, memberName: members[1].name, shareAmount: 8900, status: 'PAID' },
+      { id: 31, memberId: 2, memberName: members[2].name, shareAmount: 8900, status: 'PAID' },
+      { id: 32, memberId: 3, memberName: members[3].name, shareAmount: 8900, status: 'PAID' },
+      { id: 33, memberId: 4, memberName: members[4].name, shareAmount: 8900, status: 'PAID' },
+      { id: 34, memberId: 5, memberName: members[5].name, shareAmount: 8900, status: 'PAID' },
+    ],
+    createdAt: '2025-08-19T19:53:15.560542Z',
+    updatedAt: '2025-08-21T22:07:47.543158Z',
+  },
+  {
     id: 8,
     category: 'FOOD',
     title: '마라탕 배달비3',
@@ -118,7 +141,7 @@ export const myPaymentHistory: PaymentHistoryItem[] = [
   {
     paymentHistoryId: 8,
     settlementId: 6,
-    senderId: 3,
+    senderId: 1,
     receiverId: 2,
     amount: 15000,
     status: 'REFUNDED',
@@ -127,7 +150,7 @@ export const myPaymentHistory: PaymentHistoryItem[] = [
   {
     paymentHistoryId: 11,
     settlementId: 8,
-    senderId: 3,
+    senderId: 2,
     receiverId: 1,
     amount: 8900,
     status: 'PAID',

--- a/src/mocks/handlers/settlementHandlers.ts
+++ b/src/mocks/handlers/settlementHandlers.ts
@@ -30,7 +30,7 @@ import { settlements, myPaymentHistory, members, toCategory } from '../../mocks/
 
 const BASE = '/api'
 
-const CURRENT_GM_ID = 3 // 데모: 로그인 사용자 3(이서연)
+const CURRENT_GM_ID = 1 // 데모: 로그인 사용자 3(이서연)
 const getCurrentGmId = () => CURRENT_GM_ID
 
 /* ─────────────────────────────────────────────


### PR DESCRIPTION
## Purpose
정산 페이지 개발을 위한 API 연동 전 단계로, MSW(Mock Service Worker)를 설정하여
프론트엔드에서 실제 API 없이 목(mock) 데이터를 활용할 수 있도록 함

## Changes
- API 호출 훅(useMySettlements 등)과 MSW 연결 테스트 완료

## Screenshots/GIF
UI 변경사항 없음 (데이터 응답만 목(mock)으로 연결)

## How to test
<!-- 테스트 방법을 설명해주세요 -->
1. `npm install`로 의존성 설치 (MSW 포함)
2. 로컬 서버 실행 (`npm run dev`)
3. 정산 페이지 접속 시 mock 데이터가 정상적으로 표시되는지 확인
4. 네트워크 탭에서 요청이 `msw`에 의해 가로채지는지 확인

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 리뷰를 받았습니다
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다
- [x] `npm run typecheck`를 실행하여 타입 오류가 없습니다
- [x] `npm run build`를 실행하여 빌드가 성공합니다
