### PR TITLE
feat: 할일 랜덤 배정 구현

### DIFF
--- a/src/features/tasks/components/ExchangeModal.tsx
+++ b/src/features/tasks/components/ExchangeModal.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+
+interface Member {
+  name: string
+  avatarUrl: string
+}
+
+interface ExchangeModalProps {
+  open: boolean
+  members: Member[]
+  selected: number | null
+  onSelect: (idx: number | null) => void
+  onRequest: () => void
+  onClose: () => void
+}
+
+const ExchangeModal: React.FC<ExchangeModalProps> = ({
+  open,
+  members,
+  selected,
+  onSelect,
+  onRequest,
+  onClose,
+}) => {
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+      <div className="bg-white rounded-xl shadow-xl p-6 w-80 relative">
+        <button
+          aria-label="닫기"
+          onClick={onClose}
+          className="btn btn-sm btn-circle absolute right-4 top-4"
+        >
+          ✕
+        </button>
+        <div className="space-y-2 mb-5">
+          <label className="flex items-center space-x-2 cursor-pointer">
+            <input
+              type="radio"
+              name="group"
+              checked={selected === null}
+              onChange={() => onSelect(null)}
+              className="radio radio-sm"
+            />
+            <span className="text-sm">전체선택</span>
+          </label>
+          {members.map((member, idx) => (
+            <label
+              key={member.name}
+              className="flex items-center space-x-3 p-3 bg-base-100 rounded-lg cursor-pointer border mt-2"
+            >
+              <input
+                type="radio"
+                name="group"
+                checked={selected === idx}
+                onChange={() => onSelect(idx)}
+                className="radio radio-sm"
+              />
+              <img
+                src={member.avatarUrl}
+                alt={member.name}
+                className="w-8 h-8 rounded-full object-cover"
+              />
+              <span className="text-base">{member.name}</span>
+            </label>
+          ))}
+        </div>
+        <button className="btn btn-block btn-neutral mt-3" onClick={onRequest}>
+          요청하기
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ExchangeModal

--- a/src/features/tasks/components/TaskRandomButton.tsx
+++ b/src/features/tasks/components/TaskRandomButton.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
+import { RandomProps } from '../../../types/tasks'
 
-type Props = { onClick: () => void }
-const TaskRandomButton: React.FC<Props> = ({ onClick }) => (
-  <button className="btn btn-primary btn-sm" onClick={onClick}>
+const TaskRandomButton: React.FC<RandomProps> = ({ onClick, disabled }) => (
+  <button className="btn btn-primary btn-sm" onClick={onClick} disabled={disabled}>
     랜덤 배정하기
   </button>
 )

--- a/src/mocks/db/tasks.ts
+++ b/src/mocks/db/tasks.ts
@@ -1,7 +1,7 @@
-import { Member, RepeatDay, Template } from '../../types/tasks'
+import { Assignment, Member, RepeatDay, Template } from '../../types/tasks'
 
 /* ─────────────────────────────────────────────
-   1) 멤버(표시용) & 그룹 멤버 ID 매핑 (정산과 동일)
+   1) 멤버(표시용) & 그룹 멤버 ID 매핑
    ───────────────────────────────────────────── */
 export const members: Record<number, Member> = {
   1: { name: '최꿀꿀', profileUrl: '/avatars/u1.png' },
@@ -36,7 +36,7 @@ export const repeatDays: RepeatDay[] = [
 ]
 
 //할일 배정
-export const assignments = []
+export const assignments: Assignment[] = []
 
 // 담당자 변경 요청
 export const overrideRequests = [

--- a/src/mocks/db/tasks.ts
+++ b/src/mocks/db/tasks.ts
@@ -36,38 +36,7 @@ export const repeatDays: RepeatDay[] = [
 ]
 
 //할일 배정
-export const assignments = [
-  {
-    assignmentId: 1,
-    groupMemberId: 1,
-    templateId: 1,
-    date: '2025-08-05',
-    status: 'PENDING',
-    repeatType: 'WEEKLY',
-    createdAt: '2025-08-05T12:00:00',
-    updatedAt: '',
-  },
-  {
-    assignmentId: 2,
-    groupMemberId: 2,
-    templateId: 2,
-    date: '2025-08-05',
-    status: 'COMPLETED',
-    repeatType: 'WEEKLY',
-    createdAt: '2025-08-05T12:00:00',
-    updatedAt: '',
-  },
-  {
-    assignmentId: 3,
-    groupMemberId: 3,
-    templateId: 3,
-    date: '2025-08-05',
-    status: 'COMPLETED',
-    repeatType: 'WEEKLY',
-    createdAt: '2025-08-05T12:00:00',
-    updatedAt: '',
-  },
-]
+export const assignments = []
 
 // 담당자 변경 요청
 export const overrideRequests = [

--- a/src/mocks/handlers/tasksHandlers.ts
+++ b/src/mocks/handlers/tasksHandlers.ts
@@ -7,7 +7,7 @@ import {
   assignmentHistories,
   overrideRequestHistories,
 } from '../db/tasks'
-import { Assignment, RepeatDay, Template } from '../../types/tasks'
+import { Assignment, AssignmentBody, RepeatDay, Template } from '../../types/tasks'
 
 /* ─────────────────────────────────────────────
    0) 엔드포인트
@@ -108,39 +108,20 @@ export const tasksHandlers = [
     if (idx !== -1) repeatDays.splice(idx, 1)
     return new HttpResponse(null, { status: 204 })
   }),
-  http.get('/api/tasks/assignments', ({ request }) => {
-    const url = new URL(request.url)
-    const groupMemberId = url.searchParams.get('groupId')
-    const week = url.searchParams.get('week')
-    const memberId = url.searchParams.get('memberId')
 
-    let result = assignments
-
-    // groupId 필터링
-    if (groupMemberId) {
-      result = result.filter((a) => String(a.groupMemberId) === String(groupMemberId))
-    }
-    // week/date 필터링
-    if (week) {
-      // ISO week 포맷??
-      result = result.filter((a) => a.date.startsWith(week.split('-')[1]))
-    }
-    // memberId 필터링
-    if (memberId) {
-      result = result.filter((a) => String(a.groupMemberId) === String(memberId))
-    }
-
-    return HttpResponse.json(result, { status: 200 })
+  // 할일 배정 (GET)
+  http.get('/api/tasks/assignments', () => {
+    return HttpResponse.json(assignments, { status: 200 }) // 위에서 assignments 빈 배열이면 됨
   }),
 
   // 할일 배정 생성 (POST)
   http.post('/api/tasks/assignments', async ({ request }) => {
-    const body = (await request.json()) as Assignment
+    const body = (await request.json()) as AssignmentBody
     if (!body) {
       return HttpResponse.json({ error: 'Request body required.' }, { status: 400 })
     }
 
-    const newAssignment = {
+    const newAssignment: Assignment = {
       assignmentId: assignments.length + 1,
       status: 'PENDING',
       createdAt: new Date().toISOString(),

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import TaskHistoryButton from '../features/tasks/components/TaskHistoryButton'
 import TaskTable from '../features/tasks/components/TaskTable'
 import TaskRandomButton from '../features/tasks/components/TaskRandomButton'
@@ -6,13 +6,15 @@ import TaskExchangeButton from '../features/tasks/components/TaskExchangeButton'
 import CheckRepeat from '../features/tasks/components/CheckRepeat'
 import GroupMemberList from '../features/tasks/components/GroupMemberList'
 import HistoryModal, { TaskHistory } from '../features/tasks/components/HistoryModal'
-/* 그룹장 화면 기준 ui */
+import ExchangeModal from '../features/tasks/components/ExchangeModal'
+import { members as membersObj, repeatDays, templates } from '../mocks/db/tasks'
+import axios from 'axios'
+import { Assignment } from '../types/tasks'
 
-const members = [
-  { name: '그룹원1', avatarUrl: '/' },
-  { name: '그룹원2', avatarUrl: '/' },
-  { name: '그룹원3', avatarUrl: '/' },
-]
+const members = Object.entries(membersObj).map(([, data]) => ({
+  name: data.name,
+  avatarUrl: data.profileUrl,
+}))
 
 const historyItems: TaskHistory[] = [
   { date: '2025.07.29', task: '청소', status: '미완료' },
@@ -26,6 +28,42 @@ const historyItems: TaskHistory[] = [
 const TasksPage: React.FC = () => {
   const [repeat, setRepeat] = React.useState(true)
   const [showHistory, setShowHistory] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [selected, setSelected] = useState<number | null>(null)
+  const [assignments, setAssignments] = useState<Assignment[]>([])
+  const [isAssigned, setIsAssigned] = useState(false)
+
+  const fetchAssignments = useCallback(async () => {
+    const res = await axios.get('/api/tasks/assignments')
+    setAssignments(res.data || [])
+  }, [])
+
+  useEffect(() => {
+    fetchAssignments()
+  }, [fetchAssignments])
+
+  const handleRandomAssign = useCallback(async () => {
+    const memberIds = Object.keys(members).map(Number)
+
+    for (const tpl of templates) {
+      const repeatInfo = repeatDays.filter((rd) => rd.templateId === tpl.templateId)
+
+      for (const repeatDay of repeatInfo) {
+        const randomMemberId = memberIds[Math.floor(Math.random() * memberIds.length)]
+
+        await axios.post('/api/tasks/assignments', {
+          groupId: tpl.groupId,
+          groupMemberId: randomMemberId,
+          templateId: tpl.templateId,
+          dayOfWeek: repeatDay.dayOfWeek,
+          repeatType: 'WEEKLY',
+        })
+      }
+    }
+
+    await fetchAssignments()
+    setIsAssigned(true)
+  }, [fetchAssignments, templates, repeatDays, members])
 
   return (
     <div className="space-y-6">
@@ -33,11 +71,25 @@ const TasksPage: React.FC = () => {
         <h1 className="text-3xl font-bold text-primary">주간 업무표</h1>
         <TaskHistoryButton onClick={() => setShowHistory(true)} />
       </div>
-      <TaskTable />
+      <TaskTable assignments={assignments} />
       <div className="flex flex-col items-center space-y-4 mt-2">
         <div className="flex space-x-2">
-          <TaskRandomButton onClick={() => {}} />
-          <TaskExchangeButton onClick={() => {}} />
+          <TaskRandomButton onClick={handleRandomAssign} disabled={isAssigned} />
+          <TaskExchangeButton
+            onClick={() => {
+              setModalOpen(true)
+            }}
+          />
+          <ExchangeModal
+            open={modalOpen}
+            members={members}
+            selected={selected}
+            onSelect={setSelected}
+            onRequest={() => {
+              setModalOpen(false)
+            }}
+            onClose={() => setModalOpen(false)}
+          />
         </div>
         <CheckRepeat checked={repeat} onChange={(e) => setRepeat(e.target.checked)} />
       </div>

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -26,12 +26,35 @@ export interface DaySelectModalProps {
   positionClass?: string
 }
 
-export interface Assignment {
+//POST 요청으로 받는
+export interface AssignmentBody {
   groupId: number
   groupMemberId?: number
   templateId: number
   date: string
-  assignType: 'MANUAL' | 'AUTO'
+  status?: string
   repeatType?: string
   updatedAt?: string
+}
+
+export interface Assignment {
+  assignmentId: number
+  groupId: number
+  groupMemberId?: number
+  templateId: number
+  date?: string
+  dayOfWeek: string
+  status: string
+  repeatType?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface RandomProps {
+  onClick: () => void
+  disabled?: boolean
+}
+
+export interface TaskTableProps {
+  assignments: Assignment[]
 }

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -33,6 +33,7 @@ export interface AssignmentBody {
   templateId: number
   date: string
   status?: string
+  dayOfWeek: string
   repeatType?: string
   updatedAt?: string
 }


### PR DESCRIPTION
## Purpose
할일 페이지에서 랜덤 배정 버튼 기능 구현

## Changes
<!-- 주요 변경사항을 나열해주세요 -->
- handler 수정
- 랜덤 배정하기 눌렀을 때 정해진 요일에 프로필 사진 배정
- 교환하기 모달 추가
- 전체가 배정이 안되는 오류 수정

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] `npm run dev`를 실행하여 빌드가 성공합니다
