### PR TITLE
feat(settlement):정산 등록 모달을 재사용해 상세 조회 readOnly 모드 구현

### DIFF
--- a/src/features/settlements/components/SettlementListItem.tsx
+++ b/src/features/settlements/components/SettlementListItem.tsx
@@ -1,5 +1,5 @@
 // src/features/settlements/components/SettlementListItem.tsx
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ThreeDotsVertical, ChevronCompactDown } from 'react-bootstrap-icons'
 import settlementIcon from '../../../assets/icons/settlementIcon.svg'
 
@@ -12,6 +12,7 @@ import {
   useCancelSettlement,
 } from '../../../libs/hooks/settlements/useSettlementMutations'
 import { fromCategory } from '../../../libs/utils/categoryMapping'
+import SettlementCreateModal from './SettlementCreateModal'
 
 type SettlementListItemProps = {
   item: Settlement
@@ -23,6 +24,35 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
 
   const [cardOpen, SetCardOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const menuBtnRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const handleDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      const menuEl = menuRef.current
+      const btnEl = menuBtnRef.current
+
+      if (menuEl && !menuEl.contains(target) && btnEl && !btnEl.contains(target)) {
+        setMenuOpen(false)
+      }
+    }
+
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false)
+    }
+
+    document.addEventListener('mousedown', handleDown)
+    document.addEventListener('keydown', handleEsc)
+
+    return () => {
+      document.removeEventListener('mousedown', handleDown)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [menuOpen])
 
   const payMut = usePaySettlement()
   const cancelMut = useCancelSettlement()
@@ -63,114 +93,140 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
   }
 
   return (
-    <div
-      className={`flex flex-col border-2 border-gray-100 bg-gray-50 rounded-xl pl-4 pr-1 py-3 shadow-md
-                        overflow-hidden transition-[max-height] duration-500 ease-in-out 
-                        ${cardOpen ? 'max-h-screen' : isPayer ? 'max-h-40' : 'max-h-44'}`}
-    >
-      {/* 요약 카드 */}
-      <div className="flex justify-between items-center mb-2">
-        <span className="text-sm">{formatDateWithWeekday(settlement.createdAt)}</span>
-        <div className="relative ">
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              setMenuOpen(!menuOpen)
-            }}
-          >
-            <ThreeDotsVertical size={20} />
-          </button>
-          <div
-            role="menu"
-            className={`flex flex-col border border-neutral-400 rounded-lg shadow-md items-center justify-center absolute right-0 w-28 h-fit bg-white p-2 ${menuOpen ? 'opacity-100' : 'max-h-0 opacity-0'}`}
-          >
-            <button className="py-1 text-sm">정산 상세</button>
-            <div className="border-t w-full"></div>
-            <button
-              className="py-1 text-sm"
-              onClick={handleCancelClick}
-              disabled={cancelMut.isPending}
-            >
-              {cancelMut.isPending ? '취소 중…' : '정산 취소'}
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <div className="flex justify-between items-center">
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2 items-center">
-            <span className="border border-neutral-400 rounded-xl w-fit h-5 px-1 text-cent text-gray-500 text-xs text-center">
-              {fromCategory(settlement.category)}
-            </span>
-            <span className="font-bold text-base">{settlement.title}</span>
-          </div>
-          <div className="flex flex-col pl-1 gap-1">
-            <span className="text-sm">금액: {formatPriceKRW(settlement.settlementAmount)}</span>
-            <span
-              className={`block overflow-hidden text-sm transition-[max-height, opacity] duration-500 ease-in-out ${cardOpen ? 'opacity-0' : 'opacity-100 delay-300 max-h-10'}`}
-            >
-              참여자 {settlement.participants.length}명
-            </span>
-            {!isPayer && (
-              <span className="text-base font-bold mb-1">송금 금액 : {formatPriceKRW(myDue)}</span>
-            )}
-          </div>
-        </div>
-
-        <div
-          className={`flex justify-center items-center transition-[opacity, max-height] duration-200 ${cardOpen ? 'max-h-0 max-w-0 opacity-0 overflow-hidden' : 'h-8 w-20 opacity-100'} rounded-badge text-sm text-white font-bold mr-3`}
-          style={{ backgroundColor: pill.bg }}
-          onClick={handlePayClick}
-          aria-disabled={isPayer || isMyPaymentDone || !isPendingSettlement || payMut.isPending}
-        >
-          {payMut.isPending ? '처리 중…' : pill.text}
-        </div>
-      </div>
-
-      {/* 참여자 상세 */}
+    <>
       <div
-        className={`transition-opacity duration-500 overflow-hidden ${cardOpen ? 'opacity-100' : 'opacity-0'}`}
+        className={`flex flex-col border-2 border-gray-100 bg-gray-50 rounded-xl pl-4 pr-1 py-3 shadow-md
+                          overflow-hidden transition-[max-height] duration-500 ease-in-out 
+                          ${cardOpen ? 'max-h-screen' : isPayer ? 'max-h-40' : 'max-h-44'}`}
       >
-        <div className="flex flex-col gap-2">
-          <div className="text-sm ml-1 w-fit bg-[linear-gradient(transparent_65%,#fde68a_0)]">
-            결제자: {settlement.payerName}
-          </div>
-          {settlement.participants
-            .filter((p) => p.memberId !== settlement.payerId)
-            .map((p) => {
-              const badge =
-                p.status === 'PAID'
-                  ? { text: '송금 완료', bg: '#B3B3B3' }
-                  : { text: '송금 대기', bg: '#ffd15e' }
-
-              return (
-                <div key={p.id} className="flex pl-1 gap-2 justify-center items-center">
-                  <img src={settlementIcon} alt="프로필 사진" className="w-9 h-9" />
-                  <div className="flex flex-col flex-1 justify-center text-sm">
-                    <span>{p.memberName}</span>
-                    <span>{formatPriceKRW(p.shareAmount)}</span>
-                    {p.status === 'PAID' && <span></span>}
-                  </div>
-                  <div
-                    className="flex justify-center items-center h-8 w-20 rounded-badge text-sm text-white font-bold mr-3"
-                    style={{ backgroundColor: badge.bg }}
+        {/* 요약 카드 */}
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm">{formatDateWithWeekday(settlement.createdAt)}</span>
+          <div className="relative ">
+            <button
+              ref={menuBtnRef}
+              onClick={(e) => {
+                e.stopPropagation()
+                setMenuOpen(!menuOpen)
+              }}
+            >
+              <ThreeDotsVertical size={20} />
+            </button>
+            <div
+              role="menu"
+              ref={menuRef}
+              className={`flex flex-col border border-neutral-400 rounded-lg shadow-md items-center justify-center absolute right-0 w-28 h-fit bg-white p-2 ${menuOpen ? 'opacity-100' : 'max-h-0 opacity-0'}`}
+            >
+              <button
+                className="py-1 text-sm"
+                onClick={() => {
+                  setMenuOpen(false)
+                  setDetailOpen(true)
+                }}
+              >
+                정산 상세
+              </button>
+              {isPendingSettlement && (
+                <>
+                  <div className="border-t w-full"></div>
+                  <button
+                    className="py-1 text-sm"
+                    onClick={handleCancelClick}
+                    disabled={cancelMut.isPending}
                   >
-                    {badge.text}
-                  </div>
-                </div>
-              )
-            })}
+                    정산 취소
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
         </div>
+
+        <div className="flex justify-between items-center">
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-center">
+              <span className="border border-neutral-400 rounded-xl w-fit h-5 px-1 text-cent text-gray-500 text-xs text-center">
+                {fromCategory(settlement.category)}
+              </span>
+              <span className="font-bold text-base">{settlement.title}</span>
+            </div>
+            <div className="flex flex-col pl-1 gap-1">
+              <span className="text-sm">금액: {formatPriceKRW(settlement.settlementAmount)}</span>
+              <span
+                className={`block overflow-hidden text-sm transition-[max-height, opacity] duration-500 ease-in-out ${cardOpen ? 'opacity-0' : 'opacity-100 delay-300 max-h-10'}`}
+              >
+                참여자 {settlement.participants.length}명
+              </span>
+              {!isPayer && (
+                <span className="text-base font-bold mb-1">
+                  송금 금액 : {formatPriceKRW(myDue)}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div
+            className={`flex justify-center items-center transition-[opacity, max-height] duration-200 ${cardOpen ? 'max-h-0 max-w-0 opacity-0 overflow-hidden' : 'h-8 w-20 opacity-100'} rounded-badge text-sm text-white font-bold mr-3`}
+            style={{ backgroundColor: pill.bg }}
+            onClick={handlePayClick}
+            aria-disabled={isPayer || isMyPaymentDone || !isPendingSettlement || payMut.isPending}
+          >
+            {payMut.isPending ? '처리 중…' : pill.text}
+          </div>
+        </div>
+
+        {/* 참여자 상세 */}
+        <div
+          className={`transition-opacity duration-500 overflow-hidden ${cardOpen ? 'opacity-100' : 'opacity-0'}`}
+        >
+          <div className="flex flex-col gap-2">
+            <div className="text-sm ml-1 w-fit bg-[linear-gradient(transparent_65%,#fde68a_0)]">
+              결제자: {settlement.payerName}
+            </div>
+            {settlement.participants
+              .filter((p) => p.memberId !== settlement.payerId)
+              .map((p) => {
+                const badge =
+                  p.status === 'PAID'
+                    ? { text: '송금 완료', bg: '#B3B3B3' }
+                    : { text: '송금 대기', bg: '#ffd15e' }
+
+                return (
+                  <div key={p.id} className="flex pl-1 gap-2 justify-center items-center">
+                    <img src={settlementIcon} alt="프로필 사진" className="w-9 h-9" />
+                    <div className="flex flex-col flex-1 justify-center text-sm">
+                      <span>{p.memberName}</span>
+                      <span>{formatPriceKRW(p.shareAmount)}</span>
+                      {p.status === 'PAID' && <span></span>}
+                    </div>
+                    <div
+                      className="flex justify-center items-center h-8 w-20 rounded-badge text-sm text-white font-bold mr-3"
+                      style={{ backgroundColor: badge.bg }}
+                    >
+                      {badge.text}
+                    </div>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+
+        {/* 토글 버튼 */}
+        <button onClick={() => SetCardOpen(!cardOpen)} className="flex items-center justify-center">
+          <ChevronCompactDown
+            size={15}
+            className={`transition-transform ${cardOpen ? 'rotate-180' : ''} text-base-300`}
+          />
+        </button>
       </div>
 
-      {/* 토글 버튼 */}
-      <button onClick={() => SetCardOpen(!cardOpen)} className="flex items-center justify-center">
-        <ChevronCompactDown
-          size={15}
-          className={`transition-transform ${cardOpen ? 'rotate-180' : ''} text-base-300`}
+      {detailOpen && (
+        <SettlementCreateModal
+          onClose={() => setDetailOpen(false)}
+          mode="detail"
+          detailId={settlement.id}
         />
-      </button>
-    </div>
+      )}
+    </>
   )
 }

--- a/src/libs/api/settlements.ts
+++ b/src/libs/api/settlements.ts
@@ -20,3 +20,9 @@ export const postPaymentDone = (id: number) =>
 
 // 정산 취소
 export const cancelSettlement = (id: number) => axios.delete(SETTLEMENTS_ENDPOINTS.DELETE(id))
+
+// 정산 상세 조회
+export async function fetchSettlementDetail(id: number): Promise<Settlement> {
+  const { data } = await axios.get<Settlement>(SETTLEMENTS_ENDPOINTS.DETAIL(id))
+  return data
+}

--- a/src/libs/hooks/settlements/useMySettlements.ts
+++ b/src/libs/hooks/settlements/useMySettlements.ts
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { Settlement } from '../../../types/settlement'
-import { fetchMySettlementHistory, fetchMySettlements } from '../../api/settlements'
+import {
+  fetchMySettlementHistory,
+  fetchMySettlements,
+  fetchSettlementDetail,
+} from '../../api/settlements'
 
 export function useMySettlements() {
   return useQuery<Settlement[]>({
@@ -10,10 +14,22 @@ export function useMySettlements() {
   })
 }
 
+// 정산 히스토리
 export function useMySettlementHistory() {
   return useQuery({
     queryKey: ['settlements', 'myHistory'],
     queryFn: fetchMySettlementHistory,
+    staleTime: 30000,
+  })
+}
+
+// 정산 상세 조회
+export function useSettlementDetail(id?: number) {
+  return useQuery({
+    queryKey: ['settlementDetail', id],
+    // id가 숫자일 때만 실행
+    enabled: typeof id === 'number',
+    queryFn: () => fetchSettlementDetail(id!),
     staleTime: 30000,
   })
 }

--- a/src/mocks/handlers/settlementHandlers.ts
+++ b/src/mocks/handlers/settlementHandlers.ts
@@ -30,7 +30,7 @@ import { settlements, myPaymentHistory, members, toCategory } from '../../mocks/
 
 const BASE = '/api'
 
-const CURRENT_GM_ID = 1 // 데모: 로그인 사용자 3(이서연)
+const CURRENT_GM_ID = 3 // 데모: 로그인 사용자 3(이서연)
 const getCurrentGmId = () => CURRENT_GM_ID
 
 /* ─────────────────────────────────────────────

--- a/src/pages/Settlements.tsx
+++ b/src/pages/Settlements.tsx
@@ -38,7 +38,7 @@ export default function Settlements() {
         </div>
       </div>
 
-      {isModalOpen && <SettlementCreateModal onClose={() => setIsModalOpen(false)} />}
+      {isModalOpen && <SettlementCreateModal onClose={() => setIsModalOpen(false)} mode="create" />}
     </>
   )
 }


### PR DESCRIPTION
## Purpose
- 정산 내역에서 **상세보기 기능** 추가
- 정산 등록 모달을 재사용하여 `readOnly` 모드로 열리도록 구현

## Changes
- 상세 버튼 클릭 시 `SettlementCreateModal`을 `mode="detail"`로 호출하도록 수정
- `detailId`를 전달하여 해당 정산 내역 데이터를 표시
- 모달은 readOnly 모드로 동작하도록 구현

## Screenshots/GIF
변경 사항 없음

## How to test
1. 정산 목록 페이지에서 임의의 정산 항목 우측 메뉴 버튼 클릭
2. "정산 상세" 버튼 클릭
3. 등록 모달이 readOnly 상태로 열리며, 해당 정산 내역이 올바르게 표시되는지 확인

## Checklist
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다
- [x] `npm run typecheck`를 실행하여 타입 오류가 없습니다

