### PR TITLE
fix: 프로덕션 환경에서 Mock 데이터 반환 로직 제거

### DIFF
--- a/src/libs/api/axios.ts
+++ b/src/libs/api/axios.ts
@@ -58,17 +58,8 @@ api.interceptors.response.use(
       return Promise.reject(error)
     }
     
-    // 프로덕션에서 API 오류 시 임시 Mock 데이터 제공
-    if (import.meta.env.PROD && error.config?.url) {
-      console.warn('API Error, providing fallback data:', error.config.url)
-      
-      // 모든 API 오류에 대해 빈 배열 반환
-      return Promise.resolve({
-        data: [],
-        status: 200,
-        statusText: 'OK (Mock Data)'
-      })
-    }
+    // API 오류 로깅
+    console.error('API Error:', error.config?.url, error.response?.status, error.message)
     
     return Promise.reject(error)
   }


### PR DESCRIPTION
- axios.ts에서 API 에러 시 빈 배열 반환하던 로직 제거
- 실제 API 응답을 받을 수 있도록 수정
- Mixed Content 에러는 Vercel 환경변수로 해결 예정
