### PR TITLE
feat: 그룹원 리스트 API 연동

### DIFF
--- a/src/features/mainpage/components/UncompletedTasksModal.tsx
+++ b/src/features/mainpage/components/UncompletedTasksModal.tsx
@@ -6,20 +6,20 @@ const pendingData: Group[] = [
   {
     date: '2025.08.03(일)',
     members: [
-      { task: '분리수거', name: '그룹원1', profileUrl: '/' },
-      { task: '빨래', name: '그룹원2', profileUrl: '/' },
+      { task: '분리수거', name: '그룹원1', profileImageUrl: '/' },
+      { task: '빨래', name: '그룹원2', profileImageUrl: '/' },
     ],
   },
   {
     date: '2025.08.05(월)',
-    members: [{ task: '치킨 배달 정산', name: '그룹원3', profileUrl: '/' }],
+    members: [{ task: '치킨 배달 정산', name: '그룹원3', profileImageUrl: '/' }],
   },
   {
     date: '2025.08.08(금)',
     members: [
-      { task: '치킨 배달 정산', name: '그룹원3', profileUrl: '/' },
-      { task: '분리수거', name: '그룹원1', profileUrl: '/' },
-      { task: '설거지', name: '그룹원2', profileUrl: '/' },
+      { task: '치킨 배달 정산', name: '그룹원3', profileImageUrl: '/' },
+      { task: '분리수거', name: '그룹원1', profileImageUrl: '/' },
+      { task: '설거지', name: '그룹원2', profileImageUrl: '/' },
     ],
   },
 ]
@@ -46,7 +46,7 @@ const UncompletedTasksModal: React.FC<ModalProps> = ({ onClose }) => {
               {group.members.map((m) => (
                 <div key={m.task + m.name} className="flex items-center mb-3 last:mb-0">
                   <img
-                    src={m.profileUrl}
+                    src={m.profileImageUrl}
                     alt={m.task}
                     className="w-8 h-8 rounded-full border mr-3 bg-gray-100 object-cover"
                   />

--- a/src/features/tasks/components/ExchangeModal.tsx
+++ b/src/features/tasks/components/ExchangeModal.tsx
@@ -48,7 +48,7 @@ const ExchangeModal: React.FC<ExchangeModalProps> = ({
                   className="radio radio-sm"
                 />
                 <img
-                  src={member.profileUrl}
+                  src={member.profileImageUrl}
                   alt={member.name}
                   className="w-8 h-8 rounded-full object-cover"
                 />

--- a/src/features/tasks/components/GroupMemberItem.tsx
+++ b/src/features/tasks/components/GroupMemberItem.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Member } from '../../../types/tasks'
 
-const GroupMemberItem: React.FC<Member> = ({ name, profileUrl }) => (
+const GroupMemberItem: React.FC<Member> = ({ name, profileImageUrl }) => (
   <div className="card card-bordered bg-base-100 flex-row items-center p-2 mb-3 shadow border-base-200">
     <div className="avatar">
       <div className="w-10 h-10 rounded-full">
-        <img src={profileUrl} alt={name} />
+        <img src={profileImageUrl} alt={name} />
       </div>
     </div>
     <span className="ml-3 font-medium text-gray-700">{name}</span>

--- a/src/features/tasks/components/GroupMemberList.tsx
+++ b/src/features/tasks/components/GroupMemberList.tsx
@@ -7,7 +7,7 @@ const GroupMemberList: React.FC<GroupMemberListProps> = ({ members }) => (
     <div>
       {Array.isArray(members) &&
         members.map((member, idx) => (
-          <GroupMemberItem key={idx} name={member.name} profileUrl={member.profileUrl} />
+          <GroupMemberItem key={idx} name={member.name} profileImageUrl={member.profileImageUrl} />
         ))}
     </div>
   </div>

--- a/src/features/tasks/components/TaskTable.tsx
+++ b/src/features/tasks/components/TaskTable.tsx
@@ -14,7 +14,7 @@ import { fetchMyGroups } from '../../../libs/api/groups'
 
 const days = ['일', '월', '화', '수', '목', '금', '토']
 
-const getMemberAvatar = (groupMemberId: number) => members[groupMemberId]?.profileUrl || ''
+const getMemberAvatar = (groupMemberId: number) => members[groupMemberId]?.profileImageUrl || ''
 
 const initialEmptyTemplates: Template[] = [
   { templateId: -1, groupId: -1, category: '', createdAt: '', updatedAt: '' },

--- a/src/libs/utils/groupMemberName.ts
+++ b/src/libs/utils/groupMemberName.ts
@@ -1,0 +1,9 @@
+import { GroupMember, Member } from '../../types/tasks'
+
+//그룹 닉네임과 이름 mapping
+export function groupMembersName(groups: GroupMember[]): Member[] {
+  return groups.map((m) => ({
+    name: m.nickname,
+    profileImageUrl: m.profileImageUrl || '', // API에 profileUrl 없으면 빈 문자열 처리
+  }))
+}

--- a/src/mocks/db/tasks.ts
+++ b/src/mocks/db/tasks.ts
@@ -4,9 +4,9 @@ import { Assignment, Member, RepeatDay, Template } from '../../types/tasks'
    1) 멤버(표시용) & 그룹 멤버 ID 매핑
    ───────────────────────────────────────────── */
 export const members: Record<number, Member> = {
-  1: { name: '최꿀꿀', profileUrl: '/avatars/u1.png' },
-  2: { name: '이댕댕', profileUrl: '/avatars/u2.png' },
-  3: { name: '김냥냥', profileUrl: '/avatars/u3.png' },
+  1: { name: '최꿀꿀', profileImageUrl: '/avatars/u1.png' },
+  2: { name: '이댕댕', profileImageUrl: '/avatars/u2.png' },
+  3: { name: '김냥냥', profileImageUrl: '/avatars/u3.png' },
 }
 
 //할일 템플릿(배정표)

--- a/src/pages/Tasks.tsx
+++ b/src/pages/Tasks.tsx
@@ -12,11 +12,7 @@ import axios from 'axios'
 import { Assignment, GroupMember, TaskHistory } from '../types/tasks'
 import { fetchMyGroups } from '../libs/api/groups'
 import { isAuthenticated } from '../libs/utils/auth'
-
-const members = Object.entries(membersObj).map(([, data]) => ({
-  name: data.name,
-  profileUrl: data.profileUrl,
-}))
+import { groupMembersName } from '../libs/utils/groupMemberName'
 
 const historyItems: TaskHistory[] = [
   { date: '2025.07.29', task: '청소', status: '미완료' },
@@ -38,10 +34,11 @@ const TasksPage: React.FC = () => {
   const [error, setError] = useState('')
   const [userAuthenticated, setUserAuthenticated] = useState(false)
   const [groupId, setGroupId] = useState<number | null>(null)
+  const [groupMembers, setGroupMembers] = useState<GroupMember[]>([])
 
   const fetchAssignments = useCallback(async () => {
     if (!groupId) return
-    
+
     try {
       const res = await axios.get(`/api/tasks/assignments?groupId=${groupId}`)
       setAssignments(Array.isArray(res.data) ? res.data : [])
@@ -54,29 +51,31 @@ const TasksPage: React.FC = () => {
     fetchAssignments()
   }, [fetchAssignments])
 
-  // 인증 상태 한 번만 평가 및 저장
+  // 인증 상태 초기 설정
   useEffect(() => {
     setUserAuthenticated(isAuthenticated())
   }, [])
 
-  // 그룹 정보 로딩 (유저 인증 상태 변경 시 실행)
+  // 그룹 및 멤버 정보 로딩
   const loadGroupInfo = useCallback(async () => {
     if (!userAuthenticated) {
       setIsLeader(false)
       setError('')
       return
     }
+
     setError('')
     try {
       const data = await fetchMyGroups()
-      const groupMembers: GroupMember[] = Array.isArray(data.groupMembers) ? data.groupMembers : []
-
-      // 그룹 ID 설정
+      const groupMembersData: GroupMember[] = Array.isArray(data.groupMembers)
+        ? data.groupMembers
+        : []
+      setGroupMembers(groupMembersData)
       setGroupId(data.id)
 
-      // 실제 로그인된 유저 id 로 교체 필요 (임시로 첫 멤버 사용)
-      const loggedInUserId = groupMembers[0]?.memberId ?? null
-      const isMyLeader = groupMembers.some((m) => m.memberId === loggedInUserId && m.isLeader)
+      // 로그인 사용자 id (임시: 첫 멤버) 기반으로 리더 여부 결정
+      const loggedInUserId = groupMembersData[0]?.memberId ?? null
+      const isMyLeader = groupMembersData.some((m) => m.memberId === loggedInUserId && m.isLeader)
       setIsLeader(isMyLeader)
     } catch (e) {
       setError('그룹 정보를 불러오는 중 오류가 발생했습니다.')
@@ -88,6 +87,8 @@ const TasksPage: React.FC = () => {
     loadGroupInfo()
   }, [loadGroupInfo])
 
+  // 그룹멤버를 Member 타입으로 변환
+  const members = groupMembersName(groupMembers)
   const handleRandomAssign = useCallback(async () => {
     if (!groupId) {
       console.error('그룹 ID가 없습니다.')
@@ -97,7 +98,6 @@ const TasksPage: React.FC = () => {
     const memberIds = Object.keys(membersObj)
       .map(Number)
       .filter((id) => id > 0)
-
     if (memberIds.length === 0) {
       console.error('유효한 멤버가 없습니다.')
       return
@@ -109,7 +109,7 @@ const TasksPage: React.FC = () => {
         ? repeatInfo.map(async (repeatDay) => {
             const randomMemberId = memberIds[Math.floor(Math.random() * memberIds.length)]
             return axios.post('/api/tasks/assignments', {
-              groupId: groupId, // 동적으로 가져온 groupId 사용
+              groupId,
               groupMemberId: randomMemberId,
               templateId: tpl.templateId,
               dayOfWeek: repeatDay.dayOfWeek,
@@ -120,12 +120,11 @@ const TasksPage: React.FC = () => {
 
       await Promise.all(assignmentPromises)
     }
-
     await fetchAssignments()
     setIsAssigned(true)
   }, [fetchAssignments, groupId])
 
-  if (isLeader === null) return <div>Loading...</div>
+  if (isLeader === null) return <>Loading...</>
 
   return (
     <div className="space-y-6">

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -15,7 +15,7 @@ export interface Todo {
 
 export interface Member {
   name: string
-  profileUrl: string
+  profileImageUrl: string
   task: string
 }
 
@@ -159,36 +159,36 @@ export interface NicknameModalProps {
 }
 
 // 📰 Board Types
-export type BoardColor = 'RED' | 'BLUE' | 'GRAY' | 'ORANGE';
+export type BoardColor = 'RED' | 'BLUE' | 'GRAY' | 'ORANGE'
 
 export interface BoardPost {
-  id: number;
-  type: 'FREE' | 'ANNOUNCEMENT';
-  title: string;
-  preview: string;
-  groupId: number;
-  memberId: number;
-  color: BoardColor;
-  createdAt: string;
-  updatedAt: string;
+  id: number
+  type: 'FREE' | 'ANNOUNCEMENT'
+  title: string
+  preview: string
+  groupId: number
+  memberId: number
+  color: BoardColor
+  createdAt: string
+  updatedAt: string
 }
 
 export interface PageResponse<T> {
-  content: T[];
-  page: number;         // backend is 1-based in sample
-  size: number;
-  totalElements: number;
-  totalPages: number;
-  last: boolean;
+  content: T[]
+  page: number // backend is 1-based in sample
+  size: number
+  totalElements: number
+  totalPages: number
+  last: boolean
 }
 
 export interface PostLikes {
-  postId: number;
-  totalCount: number;
-  likers: { memberId: number; displayName: string; avatarUrl: string }[];
+  postId: number
+  totalCount: number
+  likers: { memberId: number; displayName: string; avatarUrl: string }[]
 }
 
 export interface PostLikesCount {
-  postId: number;
-  count: number;
+  postId: number
+  count: number
 }

--- a/src/types/tasks.ts
+++ b/src/types/tasks.ts
@@ -3,7 +3,7 @@ import { KorDay } from '../libs/utils/dayMapping'
 
 export interface Member {
   name: string
-  profileUrl: string
+  profileImageUrl: string
 }
 
 export interface GroupMemberListProps {
@@ -97,7 +97,7 @@ export interface GroupMember {
   memberId: number
   isLeader: boolean
   nickname: string
-  profileUrl: string
+  profileImageUrl: string
   status: string
   joinedAt: string
   leavedAt: string | null


### PR DESCRIPTION
## Purpose
속해있는 그룹의 그룹원 리스트 API 연동

## Changes
<!-- 주요 변경사항을 나열해주세요 -->
- API 연동
- 프로필 type 이름을 profileImageUrl로 수정

## Checklist
<!-- PR 제출 전 확인사항 -->
- [ ] `npm run lint`를 실행하여 린트 오류가 없습니다
- [ ] `npm run typecheck`를 실행하여 타입 오류가 없습니다
- [ ] `npm run build`를 실행하여 빌드가 성공합니다
