### PR TITLE
feat:참여자 api 연동

### DIFF
--- a/src/features/common/ImageViewer.tsx
+++ b/src/features/common/ImageViewer.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from 'react'
 import { X } from 'lucide-react'
+import { createPortal } from 'react-dom'
 
 type ImageViewerProps = {
   open: boolean
-  src: string // blob: 또는 https: 이미지 URL
+  src: string
   alt?: string
   onClose: () => void
   downloadable?: boolean
@@ -16,7 +17,7 @@ export default function ImageViewer({
   alt = '이미지 미리보기',
   onClose,
 }: ImageViewerProps) {
-  if (!open) return null
+  const isOpen = open && !!src // ← 표시 여부만 플래그로
 
   // ESC로 닫기
   useEffect(() => {
@@ -27,7 +28,9 @@ export default function ImageViewer({
     return () => window.removeEventListener('keydown', onKey)
   }, [onClose])
 
-  return (
+  if (!isOpen) return null
+
+  const node = (
     <div
       className="fixed inset-0 z-[1000] bg-black/80 flex items-center justify-center"
       role="dialog"
@@ -55,4 +58,6 @@ export default function ImageViewer({
       </div>
     </div>
   )
+
+  return createPortal(node, document.body)
 }

--- a/src/features/settlements/components/OngoingSettlements.tsx
+++ b/src/features/settlements/components/OngoingSettlements.tsx
@@ -1,19 +1,37 @@
 import LoadingSpinner from '../../common/LoadingSpinner'
 import SettlementListItem from './SettlementListItem'
-import { useGroupSettlements } from '../../../libs/hooks/settlements/useMySettlements'
+import { useMySettlements } from '../../../libs/hooks/settlements/useMySettlements'
 import ErrorCard from '../../common/ErrorCard'
+import { Settlement } from '../../../types/settlement'
 
 interface OngoingSettlementsProps {
-  groupId?: number
+  groupId: number
+  viewerId?: number
 }
 
-export default function OngoingSettlements({ groupId }: OngoingSettlementsProps) {
-  const { data, isLoading, error } = useGroupSettlements(groupId || 0)
+export default function OngoingSettlements({ groupId, viewerId }: OngoingSettlementsProps) {
+  if (!groupId) return null
+
+  const { data, isLoading, error } = useMySettlements()
 
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorCard />
 
-  const ongoing = Array.isArray(data) ? data.filter((s) => s.status === 'PENDING') : []
+  const list: Settlement[] = Array.isArray(data)
+    ? data
+    : // 페이지네이션/랩퍼 응답을 쓰는 경우 대비
+      Array.isArray((data as any)?.content)
+      ? (data as any).content
+      : []
+
+  const mine =
+    viewerId != null
+      ? list.filter(
+          (s) => s.payerId === viewerId || s.participants.some((p) => p.memberId === viewerId)
+        )
+      : list
+
+  const ongoing = mine.filter((s) => s.status === 'PENDING')
   const isEmpty = ongoing.length === 0
 
   return (
@@ -38,7 +56,7 @@ export default function OngoingSettlements({ groupId }: OngoingSettlementsProps)
         ) : (
           <>
             {ongoing.map((s) => (
-              <SettlementListItem key={s.id} item={s} viewerId={1} />
+              <SettlementListItem key={s.id} item={s} groupId={groupId} viewerId={viewerId} />
             ))}
           </>
         )}

--- a/src/features/settlements/components/ParticipantsSelectModal.tsx
+++ b/src/features/settlements/components/ParticipantsSelectModal.tsx
@@ -1,10 +1,11 @@
 import { XCircle } from 'react-bootstrap-icons'
 import settlementIcon from '../../../assets/icons/settlementIcon.svg'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
-import { GroupMembers } from '../../../mocks/db/groupMembers'
-import { users } from '../../../mocks/db/users'
 import { UIParticipant } from '../utils/participants'
+import { useGroupMembers } from '../../../libs/hooks/useGroupMembers'
+import LoadingSpinner from '../../common/LoadingSpinner'
+import ErrorCard from '../../common/ErrorCard'
 
 interface Props {
   onClose: () => void
@@ -15,23 +16,10 @@ interface Props {
 export default function ParticipantsSelectModal({ onClose, onSelect, groupId }: Props) {
   const [checked, setChecked] = useState<Record<number, boolean>>({})
 
-  // groupId에 해당하는 groupMember 정보 추출(users 정보 이용)
-  const list = useMemo<UIParticipant[]>(() => {
-    const inGroup = GroupMembers.filter((gm) => gm.groupId === groupId && gm.status === 'ACTIVE')
+  const { data: list = [], isLoading, isError } = useGroupMembers(groupId)
 
-    return inGroup.map((gm) => {
-      const user = users.find((u) => u.id === gm.memberId)
-
-      return {
-        memberId: gm.memberId,
-        memberName: user?.name ?? `멤버 ${gm.memberId}`,
-        avatar: user?.profileImageUrl,
-        shareAmount: undefined,
-        status: undefined,
-        settlementParticipantId: undefined,
-      }
-    })
-  }, [groupId])
+  if (isLoading) return <LoadingSpinner />
+  if (isError) return <ErrorCard />
 
   // 전체 선택 여부
   const allChecked = list.length > 0 && list.every((m) => checked[m.memberId])
@@ -101,7 +89,7 @@ export default function ParticipantsSelectModal({ onClose, onSelect, groupId }: 
                     />
                     <div className="flex gap-4 items-center border rounded-lg shadow-sm w-full h-14 pl-3">
                       <img
-                        src={m.avatar ?? settlementIcon}
+                        src={m.profileImageUrl ?? settlementIcon}
                         alt={`${m.memberName}의 프로필`}
                         className="w-9 h-9 rounded-full"
                       />

--- a/src/features/settlements/components/RecentSettlements.tsx
+++ b/src/features/settlements/components/RecentSettlements.tsx
@@ -1,21 +1,24 @@
 import { Link } from 'react-router-dom'
 import SettlementListItem from './SettlementListItem'
-import { useGroupSettlements } from '../../../libs/hooks/settlements/useMySettlements'
+import { useMySettlementHistory } from '../../../libs/hooks/settlements/useMySettlements'
 import LoadingSpinner from '../../common/LoadingSpinner'
 import ErrorCard from '../../common/ErrorCard'
 
 interface RecentSettlementsProps {
-  groupId?: number
+  groupId: number
+  viewerId?: number
 }
 
-export default function RecentSettlements({ groupId }: RecentSettlementsProps) {
-  const { data, isLoading, error } = useGroupSettlements(groupId || 0)
+export default function RecentSettlements({ groupId, viewerId }: RecentSettlementsProps) {
+  const { data, isLoading, error } = useMySettlementHistory({ page: 0, size: 20 })
 
   if (isLoading) return <LoadingSpinner />
   if (error) return <ErrorCard />
 
+  const list = Array.isArray(data) ? data : []
+
   // 완료된 정산
-  const completed = Array.isArray(data) ? data.filter((s) => s.status === 'COMPLETED') : []
+  const completed = list.filter((s) => s.status === 'COMPLETED')
 
   // 최신순 정렬
   const sorted = completed.sort(
@@ -56,7 +59,7 @@ export default function RecentSettlements({ groupId }: RecentSettlementsProps) {
         ) : (
           <>
             {recent2.map((s) => (
-              <SettlementListItem key={s.id} item={s} viewerId={1} />
+              <SettlementListItem key={s.id} item={s} groupId={groupId} viewerId={viewerId} />
             ))}
           </>
         )}

--- a/src/features/settlements/components/SettlementListItem.tsx
+++ b/src/features/settlements/components/SettlementListItem.tsx
@@ -16,10 +16,11 @@ import SettlementCreateModal from './SettlementCreateModal'
 
 type SettlementListItemProps = {
   item: Settlement
-  viewerId: number
+  groupId: number
+  viewerId?: number
 }
 
-export default function SettlementListItem({ item, viewerId }: SettlementListItemProps) {
+export default function SettlementListItem({ item, groupId, viewerId }: SettlementListItemProps) {
   if (!item) return null
 
   const [cardOpen, SetCardOpen] = useState(false)
@@ -58,8 +59,11 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
   const cancelMut = useCancelSettlement()
 
   const settlement = item
-  const isPayer = settlement.payerId === viewerId
-  const me = settlement.participants.find((p) => p.memberId === viewerId)
+  const isPayer = viewerId != null && settlement.payerId === viewerId
+  const me =
+    viewerId != null
+      ? settlement.participants.find((p) => p.memberId === viewerId) // [CHANGED]
+      : undefined
   const myDue = me?.shareAmount ?? 0
   const isMyPaymentDone = me?.status === 'PAID'
   const isPendingSettlement = settlement.status === 'PENDING'
@@ -126,7 +130,7 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
               >
                 정산 상세
               </button>
-              {isPendingSettlement && (
+              {isPendingSettlement && isPayer && (
                 <>
                   <div className="border-t w-full"></div>
                   <button
@@ -225,7 +229,7 @@ export default function SettlementListItem({ item, viewerId }: SettlementListIte
           onClose={() => setDetailOpen(false)}
           mode="detail"
           detailId={settlement.id}
-          groupId={1}
+          groupId={groupId}
         />
       )}
     </>

--- a/src/features/settlements/utils/participants.ts
+++ b/src/features/settlements/utils/participants.ts
@@ -1,6 +1,5 @@
 // libs/utils/participants.ts
-import { users } from '../../../mocks/db/users'
-import { SettlementParticipant, TransferStatus } from '../../../types/settlement'
+import { TransferStatus } from '../../../types/settlement'
 
 // UI에서 쓰는 참가자 타입(이미 컴포넌트에 있다면 import해서 쓰세요)
 export type UIParticipant = {
@@ -9,40 +8,26 @@ export type UIParticipant = {
   shareAmount?: number
   status?: TransferStatus
   settlementParticipantId?: number
-  avatar?: string
+  profileImageUrl?: string | null
 }
 
-// 모달이 올려주는 멤버
-export type BasicMember = {
-  memberId: number
-  memberName: string
-  avatar?: string
-}
-
-export function getAvatarByMemberId(memberId: number): string {
-  const user = users.find((u) => u.id === memberId)
-  return user?.profileImageUrl ?? '/placeholder-avatar.png'
-}
-
-// 서버 응답(상세조회 participants) -> UI 모델
-export function fromServerList(list: SettlementParticipant[] = []): UIParticipant[] {
+export function fromServerList(
+  list: Array<{
+    memberId: number
+    memberName?: string
+    shareAmount?: number | null
+    status?: TransferStatus | null
+    settlementParticipantId?: number | null
+    profileImageUrl?: string | null
+  }> = []
+): UIParticipant[] {
   return list.map((p) => ({
     memberId: p.memberId,
-    memberName: p.memberName,
-    shareAmount: p.shareAmount,
-    status: p.status,
-    settlementParticipantId: p.memberId,
-    avatar: getAvatarByMemberId(p.memberId),
-  }))
-}
-
-// 모달 선택 결과 -> UI 모델
-export function fromMembers(list: BasicMember[] = []): UIParticipant[] {
-  return list.map((m) => ({
-    memberId: m.memberId,
-    memberName: m.memberName,
-    avatar: m.avatar ?? getAvatarByMemberId(m.memberId),
-    shareAmount: undefined, // 초기값 비움
+    memberName: p.memberName ?? `멤버 ${p.memberId}`,
+    shareAmount: p.shareAmount ?? undefined,
+    status: p.status ?? undefined,
+    settlementParticipantId: p.settlementParticipantId ?? undefined,
+    profileImageUrl: p.profileImageUrl ?? null,
   }))
 }
 

--- a/src/libs/api/groups.ts
+++ b/src/libs/api/groups.ts
@@ -67,7 +67,8 @@ export async function createGroupInvitation(groupId: number) {
 }
 
 // 해당 그룹 멤버 목록
+
 export async function fetchGroupMembers(groupId: number) {
-  const response = await api.get(`/groups/${groupId}/members`)
-  return response.data
+  const { data } = await api.get(GROUP_ENDPOINTS.MEMBERS(groupId))
+  return data
 }

--- a/src/libs/hooks/settlements/useMySettlements.ts
+++ b/src/libs/hooks/settlements/useMySettlements.ts
@@ -11,7 +11,7 @@ export function useMySettlements() {
   return useQuery<Settlement[]>({
     queryKey: ['settlements', 'my'],
     queryFn: fetchMySettlements,
-    staleTime: 30000,
+    staleTime: 0,
   })
 }
 

--- a/src/libs/hooks/useGroupMembers.ts
+++ b/src/libs/hooks/useGroupMembers.ts
@@ -1,0 +1,49 @@
+import { useQuery } from '@tanstack/react-query'
+import { UIParticipant } from '../../features/settlements/utils/participants'
+import { fetchGroupMembers } from '../api/groups'
+import { useProfile } from './mypage/useProfile'
+
+type MemberResp = {
+  id: number
+  groupId: number
+  memberId: number
+  isLeader: boolean
+  nickname: string
+  status: 'ACTIVE' | 'INACTIVE' | string
+  joinedAt: string
+  leavedAt?: string | null
+  profileImageUrl?: string | null
+}
+
+export function useGroupMembers(groupId: number | null) {
+  return useQuery<UIParticipant[]>({
+    queryKey: ['groups', groupId, 'members'],
+    enabled: !!groupId,
+    queryFn: async (): Promise<UIParticipant[]> => {
+      if (!groupId) return []
+      const members = (await fetchGroupMembers(groupId)) as MemberResp[]
+      return members
+        .filter((m) => m.status === 'ACTIVE')
+        .map<UIParticipant>((m) => ({
+          memberId: m.memberId,
+          memberName: m.nickname ?? `멤버 ${m.memberId}`,
+          profileImageUrl: m.profileImageUrl,
+        }))
+    },
+  })
+}
+
+export function useMyMemberId(groupId: number | null) {
+  const { data: me } = useProfile()
+
+  return useQuery<number | undefined>({
+    queryKey: ['groups', groupId, 'myMemberId', me?.name],
+    enabled: !!groupId && !!me?.name,
+    queryFn: async () => {
+      const members = (await fetchGroupMembers(groupId!)) as MemberResp[]
+      const mine = members.find((m) => m.status === 'ACTIVE' && m.nickname === me!.name)
+      return mine?.memberId
+    },
+    staleTime: 30000,
+  })
+}

--- a/src/pages/Settlements.tsx
+++ b/src/pages/Settlements.tsx
@@ -5,13 +5,17 @@ import OngoingSettlements from '../features/settlements/components/OngoingSettle
 import RecentSettlements from '../features/settlements/components/RecentSettlements'
 import { getCurrentGroupId } from '../libs/api/groups'
 import { useParams } from 'react-router-dom'
+import { useMyMemberId } from '../libs/hooks/useGroupMembers'
 
 export default function Settlements() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [groupId, setGroupId] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  
+
+  // viewerId = 이 그룹에서의 "내 memberId"
+  const { data: viewerId } = useMyMemberId(groupId)
+
   // 라우트 파람이 없을 수도 있으니 optional로
   const { groupId: groupIdParam } = useParams<{ groupId?: string }>()
 
@@ -28,7 +32,7 @@ export default function Settlements() {
             return
           }
         }
-        
+
         // API에서 현재 그룹 ID 가져오기
         const currentGroupId = await getCurrentGroupId()
         setGroupId(currentGroupId)
@@ -39,7 +43,7 @@ export default function Settlements() {
         setLoading(false)
       }
     }
-    
+
     fetchGroupId()
   }, [groupIdParam])
 
@@ -57,10 +61,7 @@ export default function Settlements() {
       <div className="flex justify-center items-center min-h-screen">
         <div className="text-center">
           <p className="text-lg text-error mb-4">{error || '그룹 정보를 찾을 수 없습니다.'}</p>
-          <button 
-            className="btn btn-primary"
-            onClick={() => window.location.reload()}
-          >
+          <button className="btn btn-primary" onClick={() => window.location.reload()}>
             다시 시도
           </button>
         </div>
@@ -92,10 +93,10 @@ export default function Settlements() {
 
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2 items-start">
           {/* 진행 중인 정산 */}
-          <OngoingSettlements groupId={groupId} />
+          <OngoingSettlements groupId={groupId} viewerId={viewerId} />
 
           {/* 정산 내역 */}
-          <RecentSettlements groupId={groupId} />
+          <RecentSettlements groupId={groupId} viewerId={viewerId} />
         </div>
       </div>
 


### PR DESCRIPTION
## Purpose
- 참여자 선택 및 분배 로직에 필요한 참여자 API를 연동


## Changes
- 참여자 조회 API 함수 추가
- SettlementCreateModal에서 참여자 API 연동
- 참여자 선택 모달과 상태 업데이트 로직 연결
- 균등 분배 및 수동 분배 시 참여자 데이터 반영


## How to test
1. 그룹 생성 후 참여자를 추가
2. 정산 생성 모달을 열고 `참여자 선택` 버튼을 클릭
3. 서버에서 불러온 참여자 목록이 표시되는지 확인
4. 균등 분배 동작이 정상적으로 적용되는지 확인

## Checklist
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다

