### PR TITLE
feat:송금 금액 및 송금하기 기능 수정

### DIFF
--- a/src/libs/api/endpoints.ts
+++ b/src/libs/api/endpoints.ts
@@ -82,7 +82,7 @@ export const SETTLEMENT_ENDPOINTS = {
   DELETE: (settlementId: number) => `api/settlements/${settlementId}`,
   PARTICIPANTS: (settlementId: number) => `api/settlements/${settlementId}/participants`,
   PAYMENT: (settlementId: number) => `api/settlements/${settlementId}/payment`,
-  PAYMENT_DONE: (settlementId: number) => `api/settlements/${settlementId}/payment-done`,
+  PAYMENT_DONE: (settlementId: number) => `api/settlements/${settlementId}/payment`,
 
   // 영수증 관리
   RECEIPT: (settlementId: number) => `api/settlements/${settlementId}/receipt`,

--- a/src/libs/api/settlements.ts
+++ b/src/libs/api/settlements.ts
@@ -55,7 +55,7 @@ export async function fetchMySettlementHistory(
 
 // 송금하기
 export const postPaymentDone = (id: number) =>
-  api.post<Settlement>(SETTLEMENT_ENDPOINTS.PAYMENT_DONE(id)).then((r) => r.data)
+  api.post<void>(SETTLEMENT_ENDPOINTS.PAYMENT_DONE(id)).then((r) => r.data)
 
 // 정산 취소
 export const cancelSettlement = (id: number) => api.delete(SETTLEMENT_ENDPOINTS.DELETE(id))

--- a/src/libs/hooks/settlements/useSettlementMutations.ts
+++ b/src/libs/hooks/settlements/useSettlementMutations.ts
@@ -20,7 +20,10 @@ export function usePaySettlement() {
   return useMutation({
     mutationFn: (id: number) => postPaymentDone(id),
     onSuccess: () => {
+      // 목록/히스토리/그룹 모두 갱신
       qc.invalidateQueries({ queryKey: ['settlements', 'my'] })
+      qc.invalidateQueries({ queryKey: ['settlements', 'myHistory'] })
+      qc.invalidateQueries({ queryKey: ['settlements', 'group'] })
     },
   })
 }

--- a/src/libs/hooks/useGroupMembers.ts
+++ b/src/libs/hooks/useGroupMembers.ts
@@ -37,11 +37,11 @@ export function useMyMemberId(groupId: number | null) {
   const { data: me } = useProfile()
 
   return useQuery<number | undefined>({
-    queryKey: ['groups', groupId, 'myMemberId', me?.name],
-    enabled: !!groupId && !!me?.name,
+    queryKey: ['groups', groupId, 'myMemberId', me?.id],
+    enabled: !!groupId && !!me?.id,
     queryFn: async () => {
       const members = (await fetchGroupMembers(groupId!)) as MemberResp[]
-      const mine = members.find((m) => m.status === 'ACTIVE' && m.nickname === me!.name)
+      const mine = members.find((m) => m.status === 'ACTIVE' && m.memberId === me!.id)
       return mine?.memberId
     },
     staleTime: 30000,

--- a/src/types/settlement.ts
+++ b/src/types/settlement.ts
@@ -36,7 +36,14 @@ export interface Settlement {
 // 정산 내역
 export type SettlementListItem = Pick<
   Settlement,
-  'id' | 'category' | 'title' | 'settlementAmount' | 'status' | 'createdAt'
+  | 'id'
+  | 'category'
+  | 'title'
+  | 'settlementAmount'
+  | 'status'
+  | 'createdAt'
+  | 'payerId'
+  | 'payerName'
 >
 
 // 정산 등록


### PR DESCRIPTION

## Purpose
- 정산 카드에서 송금 금액 표시 및 송금하기 기능을 개선
- 송금 버튼 클릭 시 확인 모달을 통해 사용자에게 한번 더 확인을 받고, 확인 시 실제 송금 API를 호출하도록 수정

## Changes
- [x] `ConfirmModal`을 활용해 송금하기 클릭 시 확인 모달 노출
- [x] 모달에서 "확인" 버튼 클릭 시 `POST /api/settlements/{id}/payment` API 호출
- [x] 송금 완료 후 관련 settlement 쿼리(invalidate)로 UI 동기화

## How to test
1. 그룹 정산 카드에서 **참여자** 계정으로 로그인
2. `송금하기` 버튼 클릭 시 확인 모달이 노출되는지 확인
3. 모달에서 "확인" 클릭 시 송금 API 호출 및 상태가 업데이트되는지 확인
4. 송금 완료 후 카드 상태(pill)가 `송금 완료`로 변경되는지 확인

## Checklist
- [x] `npm run lint` 실행 시 오류 없음

