### PR TITLE
feat: 송금/정산 히스토리 UI 개선

### DIFF
--- a/src/features/payments/components/paymentsListItem.tsx
+++ b/src/features/payments/components/paymentsListItem.tsx
@@ -1,5 +1,5 @@
 // src/features/settlements/components/SettlementListItem.tsx
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { ThreeDotsVertical, ChevronCompactDown } from 'react-bootstrap-icons'
 import settlementIcon from '../../../assets/icons/settlementIcon.svg'
 
@@ -9,10 +9,13 @@ import type { PaymentHistoryItem, Settlement, TransferStatus } from '../../../ty
 
 import { fromCategory } from '../../../libs/utils/categoryMapping'
 import { fromTransferStatus } from '../../../libs/utils/statusMapping'
+import useOnClickOutside from '../../../libs/hooks/useOnClickOutside'
+import SettlementCreateModal from '../../settlements/components/SettlementCreateModal'
 
 type PaymentHistoryItemProps = {
   item: PaymentHistoryItem
   settlement?: Settlement
+  groupId: number
 }
 
 // 상태별 배지 색상
@@ -20,15 +23,20 @@ const STATUS_COLOR: Record<TransferStatus, string> = {
   PENDING: '#ffd15e',
   PAID: '#757575',
   REFUNDED: '#C6ADD5',
-  FAILED: '#CE6B6B',
+  FAILED: '#EC221F',
   CANCELED: '#CE6B6B',
+  REFUND_FAILED: '#725DE6',
 }
 
-export default function PaymentsListItem({ item, settlement }: PaymentHistoryItemProps) {
+export default function PaymentsListItem({ item, settlement, groupId }: PaymentHistoryItemProps) {
   if (!item) return null
 
   const [cardOpen, SetCardOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [detailOpen, setDetailOpen] = useState(false)
+
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const menuBtnRef = useRef<HTMLButtonElement | null>(null)
 
   // 배지 텍스트/색
   const pill = useMemo(
@@ -39,104 +47,132 @@ export default function PaymentsListItem({ item, settlement }: PaymentHistoryIte
     [item.status]
   )
 
+  useOnClickOutside(menuRef, (e) => {
+    if (e instanceof MouseEvent || e instanceof TouchEvent) {
+      if (menuBtnRef.current?.contains(e.target as Node)) return
+    }
+    if (menuOpen) setMenuOpen(false)
+  })
+
   return (
-    <div
-      className={`flex flex-col border-2 border-gray-100 bg-gray-50 rounded-xl pl-4 pr-1 py-3 shadow-md
+    <>
+      <div
+        className={`flex flex-col border-2 border-gray-100 bg-gray-50 rounded-xl pl-4 pr-1 py-3 shadow-md
                         overflow-hidden transition-[max-height] duration-500 ease-in-out 
                         ${cardOpen ? 'max-h-screen' : 'max-h-44'}`}
-    >
-      {/* 요약 카드 */}
-      <div className="flex justify-between items-center mb-2">
-        {/* 상단 */}
-        <span className="text-sm">{formatDateTime(item.transferAt)}</span>
-        <div className="relative ">
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              setMenuOpen(!menuOpen)
-            }}
-          >
-            <ThreeDotsVertical size={20} />
-          </button>
-          <div
-            role="menu"
-            className={`flex flex-col border border-neutral-400 rounded-lg shadow-md items-center justify-center absolute right-0 w-28 h-fit bg-white p-2 ${menuOpen ? 'opacity-100' : 'max-h-0 opacity-0'}`}
-          >
-            <button className="py-1 text-sm">정산 상세</button>
-          </div>
-        </div>
-      </div>
-
-      {/* 본문 */}
-      <div className="flex justify-between items-center">
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2 items-center">
-            <span className="border border-neutral-400 rounded-xl w-fit h-5 px-1 text-cent text-gray-500 text-xs text-center">
-              {fromCategory(settlement?.category ?? 'ETC')}
-            </span>
-            <span className="font-bold text-base">{settlement?.title}</span>
-          </div>
-          <div className="flex flex-col pl-1 gap-1">
-            <span className="text-sm">송금 금액: {formatPriceKRW(item.amount)}</span>
-            <span
-              className={`block overflow-hidden text-sm transition-[max-height, opacity] duration-500 ease-in-out ${cardOpen ? 'opacity-0' : 'opacity-100 delay-300 max-h-10'}`}
-            >
-              참여자 {settlement?.participants.length}명
-            </span>
-          </div>
-        </div>
-
-        <div
-          className={`flex justify-center items-center rounded-full transition-[opacity, max-height] duration-200 ${cardOpen ? 'max-h-0 max-w-0 opacity-0 overflow-hidden' : 'h-8 w-20 opacity-100'} rounded-badge text-sm text-white font-bold mr-3`}
-          style={{ backgroundColor: pill.bg }}
-        >
-          {pill.text}
-        </div>
-      </div>
-
-      {/* 참여자 상세 */}
-      <div
-        className={`transition-opacity duration-500 overflow-hidden ${cardOpen ? 'opacity-100' : 'opacity-0'}`}
       >
-        <div className="flex flex-col gap-2">
-          <div className="text-sm ml-1 w-fit bg-[linear-gradient(transparent_65%,#fde68a_0)]">
-            결제자: {settlement?.payerName}
+        {/* 요약 카드 */}
+        <div className="flex justify-between items-center mb-2">
+          {/* 상단 */}
+          <span className="text-sm">{formatDateTime(item.transferAt)}</span>
+          <div className="relative ">
+            <button
+              ref={menuBtnRef}
+              onClick={(e) => {
+                e.stopPropagation()
+                setMenuOpen(!menuOpen)
+              }}
+            >
+              <ThreeDotsVertical size={20} />
+            </button>
+            <div
+              role="menu"
+              ref={menuRef}
+              className={`flex flex-col border border-neutral-400 rounded-lg shadow-md items-center justify-center absolute right-0 w-28 h-fit bg-white p-2 ${menuOpen ? 'opacity-100' : 'max-h-0 opacity-0'}`}
+            >
+              <button
+                onClick={() => {
+                  setMenuOpen(false)
+                  setDetailOpen(true)
+                }}
+                className="py-1 text-sm"
+              >
+                정산 상세
+              </button>
+            </div>
           </div>
-          {settlement?.participants
-            .filter((p) => p.memberId !== settlement.payerId)
-            .map((p) => {
-              const badge =
-                p.status === 'PAID'
-                  ? { text: '송금 완료', bg: '#B3B3B3' }
-                  : { text: '송금 대기', bg: '#ffd15e' }
-
-              return (
-                <div key={p.memberId} className="flex pl-1 gap-2 justify-center items-center">
-                  <img src={settlementIcon} alt="프로필 사진" className="w-9 h-9" />
-                  <div className="flex flex-col flex-1 justify-center text-sm">
-                    <span>{p.memberName}</span>
-                    <span>{formatPriceKRW(p.shareAmount)}</span>
-                    {p.status === 'PAID' && <span></span>}
-                  </div>
-                  <div
-                    className="flex justify-center items-center h-8 w-20 rounded-badge text-sm text-white font-bold mr-3"
-                    style={{ backgroundColor: badge.bg }}
-                  >
-                    {badge.text}
-                  </div>
-                </div>
-              )
-            })}
         </div>
+
+        {/* 본문 */}
+        <div className="flex justify-between items-center">
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-center">
+              <span className="border border-neutral-400 rounded-xl w-fit h-5 px-1 text-cent text-gray-500 text-xs text-center">
+                {fromCategory(settlement?.category ?? 'ETC')}
+              </span>
+              <span className="font-bold text-base">{settlement?.title}</span>
+            </div>
+            <div className="flex flex-col pl-1 gap-1">
+              <span className="text-sm">송금 금액: {formatPriceKRW(item.amount)}</span>
+              <span
+                className={`block overflow-hidden text-sm transition-[max-height, opacity] duration-500 ease-in-out ${cardOpen ? 'opacity-0' : 'opacity-100 delay-300 max-h-10'}`}
+              >
+                참여자 {settlement?.participants.length}명
+              </span>
+            </div>
+          </div>
+
+          <div
+            className={`flex justify-center items-center rounded-full transition-[opacity, max-height] duration-200 ${cardOpen ? 'max-h-0 max-w-0 opacity-0 overflow-hidden' : 'h-8 w-20 opacity-100'} rounded-badge text-sm text-white font-bold mr-3`}
+            style={{ backgroundColor: pill.bg }}
+          >
+            {pill.text}
+          </div>
+        </div>
+
+        {/* 참여자 상세 */}
+        <div
+          className={`transition-opacity duration-500 overflow-hidden ${cardOpen ? 'opacity-100' : 'opacity-0'}`}
+        >
+          <div className="flex flex-col gap-2">
+            <div className="text-sm ml-1 w-fit bg-[linear-gradient(transparent_65%,#fde68a_0)]">
+              결제자: {settlement?.payerName}
+            </div>
+            {settlement?.participants
+              .filter((p) => p.memberId !== settlement.payerId)
+              .map((p) => {
+                const badge =
+                  p.status === 'PAID'
+                    ? { text: '송금 완료', bg: '#B3B3B3' }
+                    : { text: '송금 대기', bg: '#ffd15e' }
+
+                return (
+                  <div key={p.memberId} className="flex pl-1 gap-2 justify-center items-center">
+                    <img src={settlementIcon} alt="프로필 사진" className="w-9 h-9" />
+                    <div className="flex flex-col flex-1 justify-center text-sm">
+                      <span>{p.memberName}</span>
+                      <span>{formatPriceKRW(p.shareAmount)}</span>
+                      {p.status === 'PAID' && <span></span>}
+                    </div>
+                    <div
+                      className="flex justify-center items-center h-8 w-20 rounded-full text-sm text-white font-bold mr-3"
+                      style={{ backgroundColor: badge.bg }}
+                    >
+                      {badge.text}
+                    </div>
+                  </div>
+                )
+              })}
+          </div>
+        </div>
+
+        {/* 토글 버튼 */}
+        <button onClick={() => SetCardOpen(!cardOpen)} className="flex items-center justify-center">
+          <ChevronCompactDown
+            size={15}
+            className={`transition-transform ${cardOpen ? 'rotate-180' : ''} text-base-300`}
+          />
+        </button>
       </div>
 
-      {/* 토글 버튼 */}
-      <button onClick={() => SetCardOpen(!cardOpen)} className="flex items-center justify-center">
-        <ChevronCompactDown
-          size={15}
-          className={`transition-transform ${cardOpen ? 'rotate-180' : ''} text-base-300`}
+      {detailOpen && settlement && (
+        <SettlementCreateModal
+          onClose={() => setDetailOpen(false)}
+          mode="detail"
+          detailId={settlement.id}
+          groupId={groupId}
         />
-      </button>
-    </div>
+      )}
+    </>
   )
 }

--- a/src/features/settlements/components/SettlementListItem.tsx
+++ b/src/features/settlements/components/SettlementListItem.tsx
@@ -16,6 +16,7 @@ import SettlementCreateModal from './SettlementCreateModal'
 import ConfirmModal from '../../common/ConfirmModal'
 import axios from 'axios'
 import { DEFAULT_PROFILE_URL } from '../../../libs/utils/profile-image'
+import useOnClickOutside from '../../../libs/hooks/useOnClickOutside'
 
 type SettlementListItemProps = {
   item: Settlement
@@ -34,30 +35,12 @@ export default function SettlementListItem({ item, groupId, viewerId }: Settleme
   const menuRef = useRef<HTMLDivElement | null>(null)
   const menuBtnRef = useRef<HTMLButtonElement | null>(null)
 
-  useEffect(() => {
-    if (!menuOpen) return
-    const handleDown = (e: MouseEvent) => {
-      const target = e.target as Node
-      const menuEl = menuRef.current
-      const btnEl = menuBtnRef.current
-
-      if (menuEl && !menuEl.contains(target) && btnEl && !btnEl.contains(target)) {
-        setMenuOpen(false)
-      }
+  useOnClickOutside(menuRef, (e) => {
+    if (e instanceof MouseEvent || e instanceof TouchEvent) {
+      if (menuBtnRef.current?.contains(e.target as Node)) return
     }
-
-    const handleEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setMenuOpen(false)
-    }
-
-    document.addEventListener('mousedown', handleDown)
-    document.addEventListener('keydown', handleEsc)
-
-    return () => {
-      document.removeEventListener('mousedown', handleDown)
-      document.removeEventListener('keydown', handleEsc)
-    }
-  }, [menuOpen])
+    if (menuOpen) setMenuOpen(false)
+  })
 
   const payMut = usePaySettlement()
   const cancelMut = useCancelSettlement()

--- a/src/libs/hooks/useOnClickOutside.ts
+++ b/src/libs/hooks/useOnClickOutside.ts
@@ -1,0 +1,36 @@
+import { type RefObject, useEffect } from 'react'
+
+export default function useOnClickOutside(
+  ref: RefObject<HTMLElement>,
+  handler: (e: MouseEvent | TouchEvent | KeyboardEvent) => void
+) {
+  useEffect(() => {
+    // TODO: 여기서 document에 이벤트 등록해서
+    // ref.current 밖을 클릭하면 handler 호출하도록 만들 것
+
+    const onDown = (e: MouseEvent | TouchEvent) => {
+      const el = ref.current
+      if (!el) return
+
+      const target = e.target as Node
+      if (el.contains(target)) return // 안쪽 클릭이면 무시
+
+      handler(e)
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'escape') handler(e)
+    }
+
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('touchstart', onDown)
+    document.addEventListener('keydown', onKey)
+
+    return () => {
+      // TODO: 여기서 이벤트 정리(cleanup) 할 것
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('touchstart', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [ref, handler])
+}

--- a/src/types/settlement.ts
+++ b/src/types/settlement.ts
@@ -2,7 +2,13 @@
 export type SettlementStatus = 'PENDING' | 'COMPLETED' | 'CANCELED'
 
 // 송금 상태
-export type TransferStatus = 'PENDING' | 'PAID' | 'REFUNDED' | 'FAILED' | 'CANCELED'
+export type TransferStatus =
+  | 'PENDING'
+  | 'PAID'
+  | 'REFUNDED'
+  | 'REFUND_FAILED'
+  | 'FAILED'
+  | 'CANCELED'
 
 // 정산 카테고리
 export type SettlementCategory = 'FOOD' | 'DAILY_SUPPLIES' | 'CULTURE' | 'ETC'


### PR DESCRIPTION
## Purpose
정산/결제 히스토리 화면 개선 및 사용자 경험 향상  
- ESC/바깥 클릭 시 메뉴 닫힘 처리  
- 정산 상세 모달 연동  
- 상태별 배지 색상 및 카테고리 필터 보완  

## Changes
- `useOnClickOutside` 훅 구현 및 Settlement/Payments 리스트 컴포넌트에 적용
- ESC 키, 메뉴 외부 클릭 시 드롭다운 자동 닫힘 처리
- `SettlementCreateModal` 상세 모드 연동 (SettlementListItem / PaymentsListItem)
- `PaymentsHistory`에 `groupId` 연동 및 `settlementMap`을 통한 데이터 매핑
- 결제 상태 카테고리 매핑 보완 (PENDING, PAID, REFUNDED, REFUND_FAILED, FAILED, CANCELED)
- 상태별 배지 색상 팔레트 개선 (실패/취소/환불 실패 구분)



## How to test
1. `npm run dev`로 로컬 서버 실행
2. 결제/정산 히스토리 화면 접속
3. 아래 기능 확인:
   - ⋮ 버튼 클릭 시 메뉴 열림 → ESC/외부 클릭 시 닫힘
   - 정산 상세 클릭 시 `SettlementCreateModal` 정상 표시
   - 카테고리 필터별로 상태에 맞는 항목만 표시되는지 확인
   - 상태별 배지 색상 정상 적용되는지 확인

## Checklist
- [ ] `npm run lint`를 실행하여 린트 오류가 없습니다

