### PR TITLE
feat:프로필 정보 저장 Api 연동

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -33,15 +33,15 @@ export default function MyPage() {
       console.error('회원 탈퇴 실패:', error)
       console.error('응답 데이터:', error.response?.data)
       console.error('상태 코드:', error.response?.status)
-      
+
       let errorMessage = '회원 탈퇴에 실패했습니다. 다시 시도해주세요.'
-      
+
       if (error.response?.data?.message) {
         errorMessage = error.response.data.message
       } else if (error.response?.status === 409) {
         errorMessage = '서버에서 탈퇴를 거부했습니다. 관리자에게 문의해주세요.'
       }
-      
+
       alert(errorMessage)
     }
   }
@@ -56,8 +56,7 @@ export default function MyPage() {
   const { data: group, isLoading: groupLoading } = useMyGroups()
 
   const displayName = profileLoading ? '불러오는 중...' : (me?.name ?? '이름 없음')
-  const displayBirth = profileLoading
-  profileLoading ? '' : formatDateDots(me?.birthDate)
+  const displayBirth = profileLoading ? '' : me?.birthDate ? formatDateDots(me.birthDate) : ''
 
   return (
     <>
@@ -141,7 +140,7 @@ export default function MyPage() {
                   <button className="text-start py-1 md:pb-2 md:px-5  transition rounded-lg">
                     그룹 탈퇴
                   </button>
-                  <button 
+                  <button
                     onClick={handleWithdrawClick}
                     className="text-start py-1 md:pb-2 md:px-5 transition rounded-lg text-red-600 hover:bg-red-50"
                   >

--- a/src/pages/MyPageEdit.tsx
+++ b/src/pages/MyPageEdit.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, useEffect, useState } from 'react'
 import { CameraFill, ChevronLeft } from 'react-bootstrap-icons'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import DatePicker, { registerLocale } from 'react-datepicker'
 import { ko } from 'date-fns/locale'
 import 'react-datepicker/dist/react-datepicker.css'
@@ -37,14 +37,18 @@ export default function MyPageEdit() {
   const [alertOpen, setAlertOpen] = useState(false)
   const [alertMsg, setAlertMsg] = useState('')
 
+  const navigate = useNavigate()
+  const [lastActionSuccess, setLastActionSuccess] = useState(false)
+
   // 생년월일
   const [selectedBtdDate, setSelectedBtdDate] = useState<Date | null>(null)
 
   // 프로필 미리보기
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
 
-  // 저장 시 업로드할 파일 예약
+  // 저장 시 업로드/삭제 보류 상태
   const [pendingFile, setPendingFile] = useState<File | null>(null)
+  const [pendingDelete, setPendingDelete] = useState(false)
 
   // 프로필 이미지 삭제
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -63,6 +67,11 @@ export default function MyPageEdit() {
   const closeAlert = () => {
     setAlertOpen(false)
     setAlertMsg('')
+
+    if (lastActionSuccess) {
+      setLastActionSuccess(false)
+      navigate('/mypage')
+    }
   }
 
   // 프로필 사진
@@ -71,11 +80,11 @@ export default function MyPageEdit() {
 
   // 프로필 기본 이미지 판별
   const serverUrl = me?.profileImageUrl ?? null
-  const displayUrl = previewUrl ?? serverUrl
+  const displayUrl = previewUrl ?? (pendingDelete ? null : serverUrl)
   const isDefault = isDefaultProfileUrl(serverUrl)
 
   // 기본 이미지거나 미리보기 중이면 삭제 버튼 숨김
-  const canDelete = !!serverUrl && !isDefault && !previewUrl
+  const canDeleteServerImage = !!serverUrl && !isDefault && !previewUrl && !pendingDelete
 
   // 의존성 배열 추가 + me 로드 후 초기값 주입
   useEffect(() => {
@@ -96,6 +105,7 @@ export default function MyPageEdit() {
   // 프로필 이미지 삭제 API
   const { mutateAsync: deleteImage, isPending: deleting } = useDeleteProfileImage()
 
+  //삭제 버튼
   const askDelete = () => {
     // 처리 중에는 열지 않기
     if (uploading || deleting) return
@@ -142,6 +152,9 @@ export default function MyPageEdit() {
 
       // 서버 업로드는 저장 버튼에서 → 파일만 예약
       setPendingFile(file)
+
+      // 새 파일을 선택하면 과거의 삭제 보류는 무시
+      setPendingDelete(false)
     } catch (err) {
       showAlert('미리보기에 실패했어요. 잠시 후 다시 시도해 주세요.')
       if (previewUrl) {
@@ -154,27 +167,25 @@ export default function MyPageEdit() {
     }
   }
 
-  // 삭제는 즉시 서버에 반영
+  // 삭제 확인(저장 지연형 로직)
+  // 미리보기 중이면: 미리보기/보류 업로드만 취소 (서버 호출 X)
+  // 서버 이미지만 있으면: pendingDelete = true로 표시 (서버 호출 X, 저장 시 실제 삭제)
   const confirmDelete = async () => {
     try {
-      // 서버에서 프로필 이미지 삭제
-      await deleteImage()
       if (previewUrl) {
         URL.revokeObjectURL(previewUrl)
         setPreviewUrl(null)
+        setPendingFile(null) // 업로드 보류 취소
+      } else if (serverUrl) {
+        setPendingDelete(true) // 삭제 보류
       }
-      // 업로드 예약이 있다면 취소
-      setPendingFile(null)
-    } catch (err) {
-      showAlert('사진 삭제에 실패했어요. 잠시 후 다시 시도해 주세요.')
     } finally {
       setDeleteOpen(false)
     }
   }
-
   // 이미지 보기
   const [viewerOpen, setViewerOpen] = useState(false)
-  const currentImageSrc = previewUrl ?? me?.profileImageUrl ?? null
+  const currentImageSrc = displayUrl ?? null
   const openViewer = () => {
     if (!currentImageSrc) return
     if (uploading || deleting) return
@@ -182,14 +193,19 @@ export default function MyPageEdit() {
   }
 
   // 저장 버튼에서만 실제 업로드 실행
+  // 우선순위
+  // 1) pendingFile 이 있으면 → 업로드(이 경우 삭제 보류는 무시)
+  // 2) pendingFile 이 없고 pendingDelete === true → 삭제
+  // 3) 이미지 변경 없으면 → 프로필 정보만 업데이트 or 변경 없음 안내
   const onSave = async () => {
     try {
       if (!me) {
+        setLastActionSuccess(false)
         showAlert('프로필 정보를 불러오는 중입니다. 잠시 후 다시 시도해 주세요.')
         return
       }
 
-      // 0) 이미지 먼저 처리(있을 때만)
+      // 이미지 먼저 처리(있을 때만)
       if (pendingFile) {
         await uploadImage(pendingFile)
         setPendingFile(null)
@@ -197,6 +213,10 @@ export default function MyPageEdit() {
           URL.revokeObjectURL(previewUrl)
           setPreviewUrl(null)
         }
+        setPendingDelete(false) // 업로드가 우선이므로 삭제 보류 해제
+      } else if (pendingDelete) {
+        await deleteImage()
+        setPendingDelete(false)
       }
 
       const nextBirth = selectedBtdDate
@@ -204,26 +224,37 @@ export default function MyPageEdit() {
         : (me.birthDate ?? '')
 
       if (!nextBirth) {
+        setLastActionSuccess(false)
         showAlert('생년월일을 선택해 주세요.')
         return
       }
 
-      // gender: 화면에서 선택된 값 우선, 없으면 기존값
-      const allowed = new Set(['MALE', 'FEMALE'])
-      const nextGenderRaw = (gender || me.gender || '').toString().trim().toUpperCase()
-      const nextGender = allowed.has(nextGenderRaw) ? nextGenderRaw : 'OTHER'
+      const nextGender = (gender || me.gender || '').toString().trim()
 
-      // 변경이 없으면 굳이 호출 안 해도 되지만, 서버가 전체 업데이트를 요구한다면 호출
-      if (nextBirth === me.birthDate && nextGender === me.gender) {
+      if (nextGender !== '남자' && nextGender !== '여자') {
+        setLastActionSuccess(false)
+        showAlert('성별을 선택해 주세요.')
+        return
+      }
+
+      // 변경 여부 판단
+      const imageChanged = !!pendingFile || pendingDelete
+      const profileChanged = nextBirth !== me.birthDate || nextGender !== me.gender
+
+      if (!imageChanged && !profileChanged) {
+        setLastActionSuccess(false)
         showAlert('변경된 내용이 없습니다.')
         return
       }
 
-      // 항상 둘 다 전송
-      await updateMe({ birthDate: nextBirth, gender: nextGender })
+      if (profileChanged) {
+        await updateMe({ birthDate: nextBirth, gender: nextGender })
+      }
 
+      setLastActionSuccess(true)
       showAlert('저장되었습니다.')
     } catch (e: unknown) {
+      setLastActionSuccess(false)
       if (axios.isAxiosError(e)) {
         const d = (e as AxiosError<ApiErrorData>).response?.data
         const fieldMsg = d?.errors
@@ -296,7 +327,7 @@ export default function MyPageEdit() {
             </div>
 
             {/* 사진 삭제 버튼 (이미지/미리보기 있을 때만 노출) */}
-            {(canDelete || previewUrl) && (
+            {(canDeleteServerImage || previewUrl || pendingDelete) && (
               <div className="flex justify-center mt-3">
                 <button
                   type="button"


### PR DESCRIPTION
## Purpose
마이페이지 수정 기능을 구현 및 프로필 이미지 업로드/삭제 로직을 개선

## Changes
- 마이페이지에서 프로필 이미지 미리보기/업로드/삭제 기능 구현
- 프로필 수정(성별, 생년월일) 저장 기능 추가
- 프로필 이미지 용량 제한(1MB) 및 이미지 파일 타입 검증 추가
- 저장 성공 시 알림 모달 표시 후, 확인 버튼을 누르면 마이페이지로 이동하도록 처리
- 불필요한 any 타입 제거 및 타입 안전성 개선

## Screenshots/GIF
<!-- 필요 시 스크린샷 첨부 -->

## How to test
1. 마이페이지 → 프로필 수정 진입
2. 프로필 이미지를 업로드 → 미리보기 확인 후 저장 → 반영되는지 확인
3. 프로필 이미지를 삭제 후 저장 → 반영되는지 확인
4. 성별/생년월일 변경 후 저장 → 성공 알림 후 마이페이지 이동 확인
5. 잘못된 입력 시(1MB 이상 이미지, 이미지 아닌 파일) 에러 알림이 표시되는지 확인

## Checklist
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다

