### PR TITLE
feat:비밀번호 변경 UI 및 api 연동

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -20,7 +20,7 @@ const GroupInvite = lazy(() => import('../pages/GroupInvite'))
 const OAuthCallback = lazy(() => import('../pages/OAuthCallback'))
 const OAuthCallbackNaver = lazy(() => import('../pages/OAuthCallbackNaver'))
 const OAuthCallbackGoogle = lazy(() => import('../pages/OAuthCallbackGoogle'))
-
+const ResetPassword = lazy(() => import('../pages/ResetPassword'))
 
 export function Routes() {
   return (
@@ -33,60 +33,91 @@ export function Routes() {
       <Route path="/oauth/callback" element={<OAuthCallback />} />
       <Route path="/oauth/callback/naver" element={<OAuthCallbackNaver />} />
       <Route path="/oauth/callback/google" element={<OAuthCallbackGoogle />} />
-      
+      <Route path="/reset-password" element={<ResetPassword />} />
+
       {/* 인증 필요 라우트 - 로그인만 필요 */}
-      <Route path="/dashboard" element={
-        <ProtectedRoute requireAuth={true}>
-          <Dashboard />
-        </ProtectedRoute>
-      } />
-      
+      <Route
+        path="/dashboard"
+        element={
+          <ProtectedRoute requireAuth={true}>
+            <Dashboard />
+          </ProtectedRoute>
+        }
+      />
+
       {/* 그룹 참여 필요 라우트 - 로그인 + 그룹 참여 필요 */}
-      <Route path="/settlements" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <Settlements />
-        </ProtectedRoute>
-      } />
-      <Route path="/settlements/history" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <SettlementHistory />
-        </ProtectedRoute>
-      } />
-      <Route path="/payments/history" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <PaymentHistory />
-        </ProtectedRoute>
-      } />
-      <Route path="/tasks" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <Tasks />
-        </ProtectedRoute>
-      } />
-      <Route path="/board" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <Board />
-        </ProtectedRoute>
-      } />
-      <Route path="/mypage" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <MyPage />
-        </ProtectedRoute>
-      } />
-      <Route path="/mypage/edit" element={
-        <ProtectedRoute requireAuth={true} requireGroup={true}>
-          <MyPgeEdit />
-        </ProtectedRoute>
-      } />
-      <Route path="/create-complete" element={
-        <ProtectedRoute requireAuth={true}>
-          <GroupComplete />
-        </ProtectedRoute>
-      } />
-      <Route path="/invite" element={
-        <ProtectedRoute requireAuth={true}>
-          <GroupInvite />
-        </ProtectedRoute>
-      } />
+      <Route
+        path="/settlements"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <Settlements />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/settlements/history"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <SettlementHistory />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/payments/history"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <PaymentHistory />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/tasks"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <Tasks />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/board"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <Board />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/mypage"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <MyPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/mypage/edit"
+        element={
+          <ProtectedRoute requireAuth={true} requireGroup={true}>
+            <MyPgeEdit />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/create-complete"
+        element={
+          <ProtectedRoute requireAuth={true}>
+            <GroupComplete />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/invite"
+        element={
+          <ProtectedRoute requireAuth={true}>
+            <GroupInvite />
+          </ProtectedRoute>
+        }
+      />
 
       <Route path="*" element={<NotFound />} />
     </RouterRoutes>

--- a/src/libs/api/profile.ts
+++ b/src/libs/api/profile.ts
@@ -1,7 +1,6 @@
 import api from './axios'
 import { AUTH_ENDPOINTS, PROFILE_ENDPOINTS } from './endpoints'
 
-
 export type Profile = {
   id: number
   email: string
@@ -73,8 +72,11 @@ export async function getMyMemberId(): Promise<number> {
 }
 
 // 비밀번호 변경
-export async function refreshPassword(token: string, newPassword: string) {
-  const { data } = await api.post(AUTH_ENDPOINTS.REFRESH, { token, newPassword })
+type ResetPasswordPayload = { newPassword: string; token: string }
 
+export async function resetPassword(newPassword: string, token: string) {
+  const payload: ResetPasswordPayload = { newPassword, token }
+
+  const { data } = await api.post(AUTH_ENDPOINTS.RESET_PASSWORD, payload)
   return data
 }

--- a/src/libs/hooks/mypage/useProfile.ts
+++ b/src/libs/hooks/mypage/useProfile.ts
@@ -3,7 +3,7 @@ import {
   deleteProfileImage,
   getProfile,
   Profile,
-  refreshPassword,
+  resetPassword,
   updateAlertTime,
   updateProfile,
   UpdateProfileDto,
@@ -78,10 +78,9 @@ export function useUpdateAlertTime() {
 }
 
 // 비밀번호 변경
-
 export function useResetPassword() {
   return useMutation({
-    mutationFn: ({ token, newPassword }: { token: string; newPassword: string }) =>
-      refreshPassword(token, newPassword),
+    mutationFn: ({ newPassword, token }: { newPassword: string; token: string }) =>
+      resetPassword(newPassword, token),
   })
 }

--- a/src/pages/MyPageEdit.tsx
+++ b/src/pages/MyPageEdit.tsx
@@ -16,6 +16,7 @@ import ImageViewer from '../features/common/ImageViewer'
 import { formatYYYYMMDDLocal, parseLocalYYYYMMDD } from '../libs/utils/date-local'
 import axios, { AxiosError } from 'axios'
 import { isDefaultProfileUrl } from '../libs/utils/profile-image'
+import { api, AUTH_ENDPOINTS } from '../libs/api'
 
 registerLocale('ko', ko)
 
@@ -31,8 +32,6 @@ type ApiErrorField = { field?: string; defaultMessage?: string; message?: string
 type ApiErrorData = { message?: string; errors?: ApiErrorField[] }
 
 export default function MyPageEdit() {
-  const [pwOpen, setPwOpen] = useState(false)
-
   // 알림 컴포넌트
   const [alertOpen, setAlertOpen] = useState(false)
   const [alertMsg, setAlertMsg] = useState('')
@@ -190,6 +189,21 @@ export default function MyPageEdit() {
     if (!currentImageSrc) return
     if (uploading || deleting) return
     setViewerOpen(true)
+  }
+
+  // 이메일 발송 버튼(비밀번호 변경)
+  const onClickSendResetMail = async () => {
+    if (!me?.email) {
+      showAlert('이메일 정보를 불러오지 못했습니다.')
+      return
+    }
+
+    try {
+      await api.post(AUTH_ENDPOINTS.FORGOT_PASSWORD, { email: me.email })
+      showAlert('비밀번호 변경 이메일을 발송했습니다. 메일함을 확인해주세요.')
+    } catch (e) {
+      showAlert('메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.')
+    }
   }
 
   // 저장 버튼에서만 실제 업로드 실행
@@ -379,19 +393,6 @@ export default function MyPageEdit() {
                     <span className="text-sm">{opt.label}</span>
                   </label>
                 ))}
-
-                {/* 선택 해제용(선택 안 함) 필요하면 주석 해제 */}
-                {/* <label className="inline-flex items-center gap-2 cursor-pointer">
-      <input
-        type="radio"
-        name="gender"
-        className="radio"
-        value=""
-        checked={gender === ''}
-        onChange={() => setGender('')}
-      />
-      <span className="text-sm text-neutral-500">선택 안 함</span>
-    </label> */}
               </div>
             </div>
 
@@ -421,26 +422,18 @@ export default function MyPageEdit() {
               <span className="text-sm font-semibold text-neutral-500">보안</span>
               <button
                 className="border border-neutral rounded-full h-fit w-fit py-1 px-2 text-sm"
-                onClick={() => setPwOpen(!pwOpen)}
+                onClick={onClickSendResetMail}
               >
-                {pwOpen ? '변경 취소' : '비밀번호 변경'}
+                비밀번호 변경
               </button>
             </div>
 
-            <div
+            {/* <div
               className={`overflow-hidden transition-all duration-500 ${
                 pwOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
               }`}
             >
               <div className="flex flex-col gap-4">
-                {/* <div className="flex flex-col gap-2">
-                  <span className="text-sm">현재 비밀번호</span>
-                  <input
-                    type="password"
-                    className="input input-bordered h-10 md:max-w-md text-sm rounded-lg"
-                    placeholder="비밀번호를 입력해 주세요"
-                  />
-                </div> */}
                 <div className="flex flex-col gap-2">
                   <span className="text-sm p-1">새 비밀번호</span>
                   <input
@@ -458,7 +451,7 @@ export default function MyPageEdit() {
                   />
                 </div>
               </div>
-            </div>
+            </div> */}
           </section>
         </div>
       </main>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,158 @@
+import { ChangeEvent, FormEvent, useState } from 'react'
+import ConfirmModal from '../features/common/ConfirmModal'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useResetPassword } from '../libs/hooks/mypage/useProfile'
+
+export default function ResetPassword() {
+  const [pw, setPw] = useState('')
+  const [pw2, setPw2] = useState('')
+  const [pwMatch, setPwMatch] = useState<null | boolean>(null)
+  const [pwValid, setPwValid] = useState<null | boolean>(null)
+
+  const [params] = useSearchParams()
+  const token = params.get('token') || ''
+  const navigate = useNavigate()
+
+  const { mutateAsync: resetPassword } = useResetPassword()
+
+  const [alertOpen, setAlertOpen] = useState(false)
+  const [alertMsg, setAlertMsg] = useState('')
+  const [lastActionSuccess, setLastActionSuccess] = useState(false)
+
+  const showAlert = (msg: string) => {
+    setAlertMsg(msg)
+    setAlertOpen(true)
+  }
+
+  const closeAlert = () => {
+    setAlertMsg('')
+    setAlertOpen(false)
+
+    if (lastActionSuccess) {
+      setLastActionSuccess(false)
+      navigate('/login')
+    }
+  }
+
+  const passwordRegex = /^(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/
+
+  const handlePwChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value
+    setPw(v)
+
+    if (v === '') {
+      setPwValid(null) // 아무것도 안쓰면 표시 x
+    } else {
+      setPwValid(passwordRegex.test(v)) // 규칙 통과여부 체크
+    }
+
+    // 확인칸이 이미 입력되어 있으면 동시에 비교
+    if (pw2) {
+      setPwMatch(v === pw2)
+    }
+  }
+
+  const handlePw2Change = (e: ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value
+    setPw2(v)
+    if (pw) {
+      setPwMatch(v === pw) // 확인칸에 값이 있으면 즉시 비교
+    } else {
+      setPwMatch(null) // 원본 비밀번호가 비어있으면 비교하지 않음
+    }
+  }
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+
+    if (!token) {
+      showAlert('토큰이 없습니다. 메일의 링크로 다시 접속해주세요.')
+      return
+    }
+
+    if (!pw || !pw2) {
+      showAlert('새 비밀번호를 입력해 주세요.')
+      return
+    }
+
+    if (pw !== pw2) {
+      showAlert('새 비밀번호가 서로 다릅니다.')
+      return
+    }
+
+    if (!passwordRegex.test(pw)) {
+      showAlert('비밀번호는 최소 8자 이상이며, 특수문자를 1개 이상 포함해야 합니다.')
+      return
+    }
+
+    try {
+      await resetPassword({ newPassword: pw, token })
+      showAlert('비밀번호가 변경되었습니다. 다시 로그인해 주세요.')
+      setLastActionSuccess(true)
+    } catch (e) {
+      showAlert('비밀번호 변경에 실패했습니다. 다시 시도해 주세요.')
+    }
+  }
+
+  return (
+    <div className="flex flex-col mx-auto max-w-md px-4 py-8 min-h-[80vh] bg-base-200 shadow-xl rounded-lg">
+      <h1 className="text-2xl font-bold mb-6 text-center">비밀번호 재설정</h1>
+
+      <form onSubmit={onSubmit} className="flex-1 flex flex-col gap-4">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-2 text-xs border p-3 rounded-lg text-gray-500">
+            <p>- 최소 8자 이상 입력해 주세요</p>
+            <p>- 특수문자 최소 1개 포함하여 입력해 주세요</p>
+          </div>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm p-1">새 비밀번호</span>
+            <input
+              type="password"
+              className="input input-bordered h-10 md:max-w-md text-sm rounded-lg"
+              placeholder="새 비밀번호를 입력해 주세요"
+              value={pw}
+              onChange={handlePwChange}
+            />
+
+            {pwValid === false && (
+              <p className="text-xs text-red-500">
+                비밀번호는 최소 8자 이상이며 특수문자를 1개 이상 포함해야 합니다.
+              </p>
+            )}
+            {pwValid === true && (
+              <p className="text-xs text-green-600">사용 가능한 비밀번호입니다.</p>
+            )}
+          </div>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm">새 비밀번호 확인</span>
+            <input
+              type="password"
+              className="input input-bordered h-10 md:max-w-md text-sm rounded-lg"
+              placeholder="새 비밀번호를 다시 입력해 주세요"
+              value={pw2}
+              onChange={handlePw2Change}
+            />
+            {pwMatch === false && <p className="text-xs text-red-500">비밀번호가 서로 다릅니다.</p>}
+            {pwMatch === true && <p className="text-xs text-green-600">비밀번호가 일치합니다. </p>}
+          </div>
+        </div>
+
+        <div className="mt-auto mx-auto">
+          <button type="submit" className="btn btn-sm btn-secondary rounded-lg w-36">
+            비밀번호 변경
+          </button>
+        </div>
+      </form>
+
+      <ConfirmModal
+        open={alertOpen}
+        title="안내"
+        message={alertMsg}
+        confirmText="확인"
+        cancelText="취소"
+        onConfirm={closeAlert}
+        onCancel={closeAlert}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Purpose
- 사용자가 비밀번호를 재설정할 수 있도록 `ResetPassword` 페이지 구현
- 회원가입 시 적용된 비밀번호 검증 규칙(최소 8자, 특수문자 1개 이상 포함)을 동일하게 적용

## Changes
- `ResetPassword` 페이지 추가
  - 토큰 기반 비밀번호 재설정 폼 구현
  - 새 비밀번호 / 비밀번호 확인 입력 UI 작성
- 비밀번호 일치 여부 실시간 검증 및 안내 메시지 표시
- 비밀번호 규칙(최소 8자, 특수문자 1개 이상) 검증 로직 추가
- 비밀번호 변경 성공 시 로그인 페이지로 리다이렉트 처리
- `ConfirmModal`을 이용한 에러 및 성공 메시지 표시

## Screenshots/GIF
<!-- 필요하다면 스크린샷 첨부 -->

## How to test
1. 비밀번호 재설정 메일의 링크(`reset-password?token=...`)로 접속
2. 새 비밀번호 입력 시 규칙(8자 이상, 특수문자 포함) 검증 메시지를 확인
3. 새 비밀번호 확인 입력 시 일치/불일치 메시지를 확인
4. 비밀번호 변경 버튼 클릭 시 성공적으로 변경되고 로그인 페이지로 이동하는지 확인
5. 유효하지 않은 토큰일 경우 에러 메시지가 표시되는지 확인

## Checklist
- [x] `npm run lint`를 실행하여 린트 오류가 없습니다

