### PR TITLE
feat:알림 설정 api 연동

### DIFF
--- a/src/libs/api/endpoints.ts
+++ b/src/libs/api/endpoints.ts
@@ -154,4 +154,7 @@ export const NOTIFICATION_ENDPOINTS = {
 
   // 모든 알림 삭제
   DELETE_ALL: 'api/notifications/all',
+
+  // 알림 설정 (GET / PUT 공용)
+  SETTINGS: 'api/notifications/settings',
 } as const

--- a/src/libs/api/notifications.ts
+++ b/src/libs/api/notifications.ts
@@ -1,5 +1,11 @@
 import api from './axios'
-import { Notification, UnreadCountResponse, CreateNotificationRequest, CreateNotificationResponse } from '../../types/notification'
+import {
+  Notification,
+  UnreadCountResponse,
+  CreateNotificationRequest,
+  CreateNotificationResponse,
+} from '../../types/notification'
+import { NOTIFICATION_ENDPOINTS } from './endpoints'
 
 // 알림 목록 조회
 export const getNotifications = async (): Promise<Notification[]> => {
@@ -19,27 +25,30 @@ export const markNotificationAsRead = async (notificationId: number): Promise<vo
 }
 
 // 새 알림 생성
-export const createNotification = async (data: CreateNotificationRequest, isAppActive: boolean = false): Promise<CreateNotificationResponse> => {
+export const createNotification = async (
+  data: CreateNotificationRequest,
+  isAppActive: boolean = false
+): Promise<CreateNotificationResponse> => {
   try {
     console.log('📤 알림 생성 요청 데이터:', data)
     console.log('📤 isAppActive:', isAppActive)
-    
+
     const response = await api.post('/api/notifications', data, {
       headers: {
-        'isAppActive': isAppActive.toString()
-      }
+        isAppActive: isAppActive.toString(),
+      },
     })
-    
+
     console.log('✅ 알림 생성 성공:', response.data)
     return response.data
   } catch (error: unknown) {
-    const err = error as { 
-      response?: { 
-        status?: number; 
-        data?: { message?: string; error?: string }; 
-        headers?: unknown 
-      }; 
-      config?: unknown 
+    const err = error as {
+      response?: {
+        status?: number
+        data?: { message?: string; error?: string }
+        headers?: unknown
+      }
+      config?: unknown
     }
     console.error('❌ 알림 생성 실패 상세 정보:')
     console.error('에러 객체:', error)
@@ -47,7 +56,7 @@ export const createNotification = async (data: CreateNotificationRequest, isAppA
     console.error('응답 데이터:', err.response?.data)
     console.error('응답 헤더:', err.response?.headers)
     console.error('요청 설정:', err.config)
-    
+
     // 서버에서 반환한 구체적인 에러 메시지가 있다면 사용
     if (err.response?.data?.message) {
       throw new Error(`알림 생성 실패: ${err.response.data.message}`)
@@ -62,4 +71,21 @@ export const createNotification = async (data: CreateNotificationRequest, isAppA
 // 모든 알림 삭제
 export const deleteAllNotifications = async (): Promise<void> => {
   await api.delete('/api/notifications/all')
+}
+
+export type NotificationSettings = {
+  taskEnabled: boolean
+  announcementEnabled: boolean
+  settlementEnabled: boolean
+}
+
+// 알림 설정
+export async function getNotificationsSettings() {
+  const { data } = await api.get<NotificationSettings>(NOTIFICATION_ENDPOINTS.SETTINGS)
+
+  return data
+}
+
+export async function updateNotificationsSettings(body: NotificationSettings) {
+  await api.put(NOTIFICATION_ENDPOINTS.SETTINGS, body)
 }

--- a/src/libs/api/profile.ts
+++ b/src/libs/api/profile.ts
@@ -55,8 +55,8 @@ export async function deleteProfileImage(): Promise<Profile> {
 }
 
 // 알림 시간 변경
-export async function updateAlertTime(hour: number, minute: number): Promise<Profile> {
-  const { data } = await api.put<Profile>(PROFILE_ENDPOINTS.UPDATE_ALERT_TIME, { hour, minute })
+export async function updateAlertTime(alertTime: string): Promise<Profile> {
+  const { data } = await api.put<Profile>(PROFILE_ENDPOINTS.UPDATE_ALERT_TIME, { alertTime })
   return data
 }
 

--- a/src/libs/hooks/mypage/useProfile.ts
+++ b/src/libs/hooks/mypage/useProfile.ts
@@ -18,7 +18,8 @@ export function useProfile() {
   return useQuery<Profile>({
     queryKey: PROFILE_KEY,
     queryFn: getProfile,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
+    refetchOnMount: 'always',
   })
 }
 
@@ -69,10 +70,12 @@ export function useDeleteProfileImage() {
 export function useUpdateAlertTime() {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: ({ hour, minute }: { hour: number; minute: number }) =>
-      updateAlertTime(hour, minute),
-    onSuccess: (p: Profile) => {
-      qc.setQueryData(PROFILE_KEY, p)
+    mutationFn: ({ alertTime }: { alertTime: string }) => updateAlertTime(alertTime),
+    onSuccess: (_data, { alertTime }) => {
+      qc.setQueryData(PROFILE_KEY, (old: Profile | undefined) =>
+        old ? { ...old, alertTime } : old
+      )
+      qc.invalidateQueries({ queryKey: PROFILE_KEY })
     },
   })
 }

--- a/src/libs/hooks/useNotifications.ts
+++ b/src/libs/hooks/useNotifications.ts
@@ -1,6 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
-import { getUnreadCount } from '../api/notifications'
+import {
+  getNotificationsSettings,
+  getUnreadCount,
+  NotificationSettings,
+  updateNotificationsSettings,
+} from '../api/notifications'
 import { useAuth } from '../../contexts/AuthContext'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useProfile } from './mypage/useProfile'
 
 export const useNotifications = () => {
   const [unreadCount, setUnreadCount] = useState(0)
@@ -37,9 +44,12 @@ export const useNotifications = () => {
   useEffect(() => {
     if (!isAuthenticated) return
 
-    const interval = setInterval(() => {
-      fetchUnreadCount()
-    }, 5 * 60 * 1000) // 5분
+    const interval = setInterval(
+      () => {
+        fetchUnreadCount()
+      },
+      5 * 60 * 1000
+    ) // 5분
 
     return () => clearInterval(interval)
   }, [isAuthenticated, fetchUnreadCount])
@@ -48,6 +58,34 @@ export const useNotifications = () => {
     unreadCount,
     loading,
     fetchUnreadCount,
-    updateUnreadCount
+    updateUnreadCount,
   }
+}
+
+export const NOTI_SETTINGS_KEY = ['notifications', 'settings'] as const
+
+/** 알림 설정 조회 (GET /api/notifications/settings) */
+export function useNotificationsSettings() {
+  const { data: me } = useProfile()
+  return useQuery({
+    queryKey: [NOTI_SETTINGS_KEY, me?.id],
+    queryFn: getNotificationsSettings,
+    enabled: !!me?.id,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  })
+}
+
+/** 알림 설정 저장 (PUT /api/notifications/settings) */
+export function useUpdateNotificationSetting() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (body: NotificationSettings) => updateNotificationsSettings(body),
+    onSuccess: (_data, body) => {
+      // 즉시 캐시 갱신
+      qc.setQueryData(NOTI_SETTINGS_KEY, body)
+      // 저장 후 목록 재검증
+      qc.invalidateQueries({ queryKey: NOTI_SETTINGS_KEY })
+    },
+  })
 }

--- a/src/libs/utils/time.ts
+++ b/src/libs/utils/time.ts
@@ -15,3 +15,12 @@ export function from24h(hour24: number, minute: number) {
   const hour12 = ((hour24 + 11) % 12) + 1 // 0→12, 13→1
   return { hour12, minute, meridiem }
 }
+
+export const formatHHmm = (h: number, m: number) =>
+  `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
+
+export const parseHHmm = (s: string) => {
+  const m = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(s)
+  if (!m) return null
+  return { hour: Number(m[1]), minute: Number(m[2]) }
+}


### PR DESCRIPTION
## Purpose
기존에 구현된 알림 설정 UI에 **API 연동**을 추가(토글/알림시간 저장·조회)

## Changes
- 알림 설정 조회/저장 연동
  - `GET /api/notifications/settings` → 초기 토글값 반영
  - `PUT /api/notifications/settings` → 토글 저장
- 알림 시간 저장 연동
  - `PUT /api/members/profile/alert-time` (`{ "alertTime": "HH:mm" }`)
  - `parseHHmm`/`formatHHmm` 유틸 적용
- React Query 캐시 처리
  - 저장 시 `setQueryData` 즉시 반영 + `invalidateQueries`로 검증
- 실패 시 `ConfirmModal` 노출, 성공 시 `/mypage` 이동

## How to test
1. 알림 설정 모달을 열어 서버 값이 초기화되는지 확인
2. 토글/시간 변경 후 **저장**을 누름
   - Network 탭에서 위 API들이 정상 호출되는지 확인
3. 모달을 다시 열어 변경한 값이 그대로 표시되는지 확인

## Screenshots/GIF
- (UI 변경 없음)

## Checklist
- [ ] `npm run lint`에서 린트 오류가 없습니다
