### PR TITLE
feat:그룹 탈퇴 요청 api 연동

### DIFF
--- a/src/features/common/ReasonModal.tsx
+++ b/src/features/common/ReasonModal.tsx
@@ -1,0 +1,76 @@
+// src/features/common/ReasonModal.tsx
+import { useEffect, useState } from 'react'
+
+type ReasonModalProps = {
+  open: boolean
+  title: string
+  message?: string
+  placeholder?: string
+  maxLength?: number
+  initialValue?: string
+  confirmText?: string
+  cancelText?: string
+  isSubmitting?: boolean
+  onConfirm: (reason: string) => void
+  onCancel: () => void
+}
+
+export default function ReasonModal({
+  open,
+  title,
+  message,
+  placeholder = '사유를 입력하세요',
+  maxLength = 100,
+  initialValue = '',
+  confirmText = '요청하기',
+  cancelText = '취소',
+  isSubmitting = false,
+  onConfirm,
+  onCancel,
+}: ReasonModalProps) {
+  const [reason, setReason] = useState(initialValue)
+
+  useEffect(() => {
+    if (open) setReason(initialValue ?? '')
+  }, [open, initialValue])
+
+  if (!open) return null
+
+  const disabled = isSubmitting || reason.trim().length === 0
+
+  return (
+    <div className="modal modal-open">
+      <div className="modal-box rounded-lg">
+        <h3 className="font-bold text-lg">{title}</h3>
+        {message && <p className="mt-1 text-sm text-base-content/70">{message}</p>}
+
+        <textarea
+          className="textarea textarea-bordered w-full mt-3 rounded-lg"
+          rows={4}
+          placeholder={placeholder}
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          maxLength={maxLength}
+        />
+
+        <div className="mt-2 text-right text-xs text-base-content/60">
+          {reason.length}/{maxLength}
+        </div>
+
+        <div className="modal-action">
+          <button className="btn btn-sm rounded-lg" onClick={onCancel} disabled={isSubmitting}>
+            {cancelText}
+          </button>
+          <button
+            className="btn btn-sm btn-primary rounded-lg"
+            onClick={() => onConfirm(reason.trim())}
+            disabled={disabled}
+            aria-busy={isSubmitting}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/libs/api/endpoints.ts
+++ b/src/libs/api/endpoints.ts
@@ -32,7 +32,6 @@ export const GROUP_ENDPOINTS = {
 
   // 탈퇴 요청
   LEAVE_REQUESTS: (groupId: number) => `/api/groups/${groupId}/leave-requests`,
-  LEAVE_REQUEST: (groupId: number) => `/api/groups/${groupId}/leave-requests`,
   APPROVE_LEAVE: (groupId: number, requestId: number) =>
     `/api/groups/${groupId}/leave-requests/${requestId}`,
 

--- a/src/libs/api/groups.ts
+++ b/src/libs/api/groups.ts
@@ -8,12 +8,12 @@ export async function fetchMyGroups() {
   try {
     const response = await api.get(GROUP_ENDPOINTS.MY_GROUPS)
     // 그룹 정보 조회 성공
-    
+
     // 응답 데이터 검증
     if (!response.data) {
       return []
     }
-    
+
     return response.data
   } catch (error: unknown) {
     const err = error as { response?: { status?: number } }
@@ -21,13 +21,13 @@ export async function fetchMyGroups() {
     if (err.response?.status === 404) {
       return []
     }
-    
+
     // 401 에러는 인증 문제
     if (err.response?.status === 401) {
       console.error('❌ 인증이 필요합니다. 로그인해주세요.')
       throw new Error('인증이 필요합니다. 로그인해주세요.')
     }
-    
+
     // 기타 에러는 그대로 throw
     throw error
   }
@@ -48,16 +48,16 @@ export async function getCurrentGroupId(): Promise<number | null> {
   try {
     // getCurrentGroupId 호출
     const groupData = await fetchMyGroups()
-    
+
     // 응답 데이터 구조 확인
     // 그룹 데이터 구조 확인
-    
+
     // 응답에서 그룹 ID를 반환
     if (groupData && groupData.id) {
       // 현재 그룹 ID 확인
       return groupData.id
     }
-    
+
     // 다른 가능한 응답 구조 확인
     if (groupData && Array.isArray(groupData) && groupData.length > 0) {
       const firstGroup = groupData[0]
@@ -66,7 +66,7 @@ export async function getCurrentGroupId(): Promise<number | null> {
         return firstGroup.id
       }
     }
-    
+
     // 그룹이 없는 경우 null 반환 (에러가 아님)
     console.log('ℹ️ 그룹에 속하지 않음')
     return null
@@ -77,7 +77,7 @@ export async function getCurrentGroupId(): Promise<number | null> {
       console.log('ℹ️ 그룹이 없음 (404)')
       return null
     }
-    
+
     // 기타 에러는 그대로 throw
     throw error
   }
@@ -113,7 +113,7 @@ export async function createGroupInvitation(groupId: number) {
 // 해당 그룹 멤버 목록
 export async function fetchGroupMembers(groupId: number) {
   // fetchGroupMembers 호출
-  
+
   const response = await api.get(GROUP_ENDPOINTS.MEMBERS(groupId))
   // 그룹 멤버 정보 조회 성공
   return response.data
@@ -122,8 +122,32 @@ export async function fetchGroupMembers(groupId: number) {
 // 현재 사용자의 그룹 멤버 정보 조회 (memberId 포함)
 export async function getMyGroupMemberInfo(groupId: number) {
   // getMyGroupMemberInfo 호출
-  
+
   const response = await api.put(GROUP_ENDPOINTS.UPDATE_MY_INFO(groupId), {})
   // 내 그룹 멤버 정보 조회 성공
   return response.data
+}
+
+// 그룹 탈퇴 요청
+export type LeaveRequestStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'INACTIVE'
+
+export type GroupLeaveRequest = {
+  id: number
+  groupId: number
+  memberId: number
+  reason: string
+  status: LeaveRequestStatus // POST 응답은 'PENDING'
+  requestedAt: string
+  respondedAt: string | null
+}
+
+export async function requestGroupLeave(
+  groupId: number,
+  reason: string
+): Promise<GroupLeaveRequest> {
+  const { data } = await api.post<GroupLeaveRequest>(GROUP_ENDPOINTS.LEAVE_REQUESTS(groupId), {
+    reason,
+  })
+
+  return data
 }

--- a/src/libs/hooks/useGroupMembers.ts
+++ b/src/libs/hooks/useGroupMembers.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { UIParticipant } from '../../features/settlements/utils/participants'
-import { fetchGroupMembers, fetchMyGroups } from '../api/groups'
+import { fetchGroupMembers, fetchMyGroups, requestGroupLeave } from '../api/groups'
 import { useProfile } from './mypage/useProfile'
 
 type MemberResp = {
@@ -74,5 +74,21 @@ export function useMyGroups() {
     queryKey: ['groups', 'me'],
     queryFn: fetchMyGroups,
     staleTime: 5 * 60 * 1000,
+  })
+}
+
+// 그룹 탈퇴
+export function useRequestGroupLeave() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ groupId, reason }: { groupId: number; reason: string }) =>
+      requestGroupLeave(groupId, reason),
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ['myGroup'] }),
+        qc.invalidateQueries({ queryKey: ['groups'] }),
+        qc.invalidateQueries({ queryKey: ['groups', 'members'] }),
+      ])
+    },
   })
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,58 +1,73 @@
+// src/pages/MyPage.tsx
 import { useState } from 'react'
 import { Cake2, Gear } from 'react-bootstrap-icons'
 import { Link, useNavigate } from 'react-router-dom'
 import AlarmSettingModal from '../features/mypage/components/AlarmSettingModal'
 import ConfirmModal from '../features/common/ConfirmModal'
+import ReasonModal from '../features/common/ReasonModal'
 import { useProfile } from '../libs/hooks/mypage/useProfile'
 import { withdrawUser } from '../libs/api/profile'
 import { logout } from '../libs/utils/auth'
 import { useAuth } from '../contexts/AuthContext'
 import { formatDateDots } from '../libs/utils/format'
-import { useMyGroups } from '../libs/hooks/useGroupMembers'
+import { useMyGroups, useRequestGroupLeave } from '../libs/hooks/useGroupMembers'
 
 export default function MyPage() {
+  const { data: me, isLoading: profileLoading } = useProfile()
+  const { refreshAuthState } = useAuth()
+  const { data: group, isLoading: groupLoading } = useMyGroups()
+  const { mutateAsync: requestLeave, isPending: submittingLeave } = useRequestGroupLeave()
+  const navigate = useNavigate()
+
+  // 기본 모달들
   const [alarmSettingModalOpen, setAlarmSettingModalOpen] = useState(false)
   const [showWithdrawModal, setShowWithdrawModal] = useState(false)
   const [showWithdrawSuccessModal, setShowWithdrawSuccessModal] = useState(false)
-
-  // 로그아웃 확인/에러 안내 모달 상태
   const [showLogoutModal, setShowLogoutModal] = useState(false)
-  const [showErrorModal, setShowErrorModal] = useState(false)
-  const [errorMsg, setErrorMsg] = useState('')
 
+  // 공용 안내 모달(에러/정보)
+  const [showInfoModal, setShowInfoModal] = useState(false)
+  const [infoMsg, setInfoMsg] = useState('')
+
+  // 로그아웃 진행
   const [loggingOut, setLoggingOut] = useState(false)
-  const navigate = useNavigate()
 
-  const { data: me, isLoading: profileLoading } = useProfile()
-  const { refreshAuthState } = useAuth()
+  // 그룹 탈퇴: 승인중 뱃지 + 사유 입력 모달
+  const [leavePendingLocal, setLeavePendingLocal] = useState(false)
+  const [showLeaveReasonModal, setShowLeaveReasonModal] = useState(false)
 
-  // 로그아웃 처리
+  // 그룹 가입 여부 & 승인중 여부 (UI 전용)
+  const groupId = group?.id
+  const hasGroup = Boolean(groupId)
+  const isLeavePending = leavePendingLocal
+
+  // 로그아웃
   const handleLogout = async () => {
     if (loggingOut) return
     setLoggingOut(true)
-
     try {
-      // 토큰/세션 삭제
       await logout()
-      // 전역 인증 상태 갱신
       refreshAuthState()
-      // 로그인 페이지로 이동
       navigate('/login')
     } catch (e) {
       console.error('로그아웃 실패:', e)
-      setErrorMsg('로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.')
-      setShowErrorModal(true)
+      setInfoMsg('로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.')
+      setShowInfoModal(true)
     } finally {
       setLoggingOut(false)
     }
   }
 
-  // 회원 탈퇴 확인 모달 열기
+  // 회원 탈퇴
   const handleWithdrawClick = () => {
-    setShowWithdrawModal(true)
+    if (hasGroup) {
+      setInfoMsg('그룹에 가입되어 있습니다. 그룹 탈퇴를 먼저 진행해 주세요.')
+      setShowInfoModal(true)
+    } else {
+      setShowWithdrawModal(true)
+    }
   }
 
-  // 회원 탈퇴 처리
   const handleWithdraw = async () => {
     try {
       await withdrawUser()
@@ -60,23 +75,16 @@ export default function MyPage() {
       setShowWithdrawSuccessModal(true)
     } catch (error: any) {
       console.error('회원 탈퇴 실패:', error)
-      console.error('응답 데이터:', error.response?.data)
-      console.error('상태 코드:', error.response?.status)
-
-      let errorMessage = '회원 탈퇴에 실패했습니다. 다시 시도해주세요.'
-
-      if (error.response?.data?.message) {
-        errorMessage = error.response.data.message
-      } else if (error.response?.status === 409) {
-        errorMessage = '서버에서 탈퇴를 거부했습니다. 관리자에게 문의해주세요.'
-      }
-
-      setErrorMsg(errorMessage)
-      setShowErrorModal(true)
+      const errorMessage =
+        error?.response?.data?.message ??
+        (error?.response?.status === 409
+          ? '서버에서 탈퇴를 거부했습니다. 관리자에게 문의해주세요.'
+          : '회원 탈퇴에 실패했습니다. 다시 시도해주세요.')
+      setInfoMsg(errorMessage)
+      setShowInfoModal(true)
     }
   }
 
-  // 회원 탈퇴 완료 후 처리
   const handleWithdrawSuccess = async () => {
     setShowWithdrawSuccessModal(false)
     await logout()
@@ -84,7 +92,35 @@ export default function MyPage() {
     navigate('/login')
   }
 
-  const { data: group, isLoading: groupLoading } = useMyGroups()
+  // 그룹 탈퇴: 사유 입력 모달 열기
+  const handleOpenLeave = () => {
+    setShowLeaveReasonModal(true)
+  }
+
+  // 그룹 탈퇴: 요청하기
+  const handleConfirmLeave = async (reason: string) => {
+    if (!groupId) {
+      setShowLeaveReasonModal(false)
+      setInfoMsg('탈퇴할 그룹을 찾을 수 없습니다.')
+      setShowInfoModal(true)
+      return
+    }
+    try {
+      const res = await requestLeave({ groupId, reason })
+      if (res.status === 'PENDING') {
+        setLeavePendingLocal(true)
+      }
+      setShowLeaveReasonModal(false)
+      setInfoMsg('그룹장에게 탈퇴 요청이 전달되었습니다. 승인 후 반영됩니다.')
+      setShowInfoModal(true)
+    } catch (e: any) {
+      setShowLeaveReasonModal(false)
+      const msg =
+        e?.response?.data?.message ?? '그룹 탈퇴 요청에 실패했습니다. 잠시 후 다시 시도해주세요.'
+      setInfoMsg(msg)
+      setShowInfoModal(true)
+    }
+  }
 
   const displayName = profileLoading ? '불러오는 중...' : (me?.name ?? '이름 없음')
   const displayBirth = profileLoading ? '' : me?.birthDate ? formatDateDots(me.birthDate) : ''
@@ -99,21 +135,19 @@ export default function MyPage() {
           <section>
             <div className="card border border-neutral-200 shadow rounded-lg md:h-40">
               <div className="card-body relative flex justify-center px-10">
-                {/* 프로필 편집 버튼 */}
                 <div className="flex justify-end absolute right-5 top-5">
                   <Link to={'/mypage/edit'}>
                     <Gear />
                   </Link>
                 </div>
 
-                {/* 프로필 영역 */}
                 <div className="flex items-center gap-6">
                   <div className="pl-2">
                     {profileLoading ? (
                       <div className="skeleton w-16 h-16 rounded-full" />
                     ) : (
                       <img
-                        src={me!.profileImageUrl!}
+                        src={me?.profileImageUrl ?? ''}
                         alt="프로필"
                         className="w-16 h-16 rounded-full object-cover border"
                       />
@@ -136,7 +170,7 @@ export default function MyPage() {
           </section>
 
           <div className="grid grid-cols-1 gap-6">
-            {/* 마이페이지 리스트 목록 */}
+            {/* 마이페이지 리스트 */}
             <section className="grid grid-cols-2 gap-3">
               {[
                 { to: '/settlements/history', label: '정산 히스토리' },
@@ -154,7 +188,7 @@ export default function MyPage() {
               ))}
             </section>
 
-            {/* 설정 & 로그아웃 */}
+            {/* 설정 & 로그아웃/그룹탈퇴/회원탈퇴 */}
             <section>
               <div className="card border border-neutral-200 shadow rounded-lg p-2 md:p-0">
                 <div className="card-body px-3 py-1 md:py-4">
@@ -172,9 +206,21 @@ export default function MyPage() {
                   >
                     로그아웃
                   </button>
-                  <button className="text-start py-1 md:pb-2 md:px-5  transition rounded-lg">
+
+                  {/* 그룹 탈퇴: 사유 입력 모달 */}
+                  <button
+                    onClick={handleOpenLeave}
+                    disabled={!hasGroup || isLeavePending || submittingLeave}
+                    className="text-start py-1 md:pb-2 md:px-5 transition rounded-lg disabled:opacity-50 inline-flex items-center gap-2"
+                  >
                     그룹 탈퇴
+                    {isLeavePending && (
+                      <span className="border border-red-600 text-xs text-red-600 px-1 rounded-lg ml-2">
+                        그룹장 승인 대기
+                      </span>
+                    )}
                   </button>
+
                   <button
                     onClick={handleWithdrawClick}
                     className="text-start py-1 md:pb-2 md:px-5 transition rounded-lg text-red-600 hover:bg-red-50"
@@ -187,9 +233,12 @@ export default function MyPage() {
           </div>
         </div>
       </div>
+
+      {/* 알림 설정 */}
       {alarmSettingModalOpen && (
         <AlarmSettingModal onClose={() => setAlarmSettingModalOpen(false)} />
       )}
+
       {/* 로그아웃 확인 모달 */}
       <ConfirmModal
         open={showLogoutModal}
@@ -204,7 +253,7 @@ export default function MyPage() {
         onCancel={() => setShowLogoutModal(false)}
       />
 
-      {/* 회원 탈퇴 확인 모달 */}
+      {/* 회원 탈퇴 확인 */}
       <ConfirmModal
         open={showWithdrawModal}
         title="회원 탈퇴"
@@ -215,7 +264,7 @@ export default function MyPage() {
         onCancel={() => setShowWithdrawModal(false)}
       />
 
-      {/* 회원 탈퇴 완료 모달 */}
+      {/* 회원 탈퇴 완료 */}
       <ConfirmModal
         open={showWithdrawSuccessModal}
         title="회원 탈퇴 완료"
@@ -226,15 +275,32 @@ export default function MyPage() {
         onCancel={handleWithdrawSuccess}
       />
 
-      {/* 에러 안내(단일 버튼) 모달 */}
+      {/* 공용 안내(정보/에러) 모달 */}
       <ConfirmModal
-        open={showErrorModal}
-        title="알림"
-        message={errorMsg}
+        open={showInfoModal}
+        title="안내"
+        message={infoMsg}
         confirmText="확인"
-        cancelText=""
-        onConfirm={() => setShowErrorModal(false)}
-        onCancel={() => setShowErrorModal(false)}
+        cancelText="취소"
+        onConfirm={() => setShowInfoModal(false)}
+        onCancel={() => setShowInfoModal(false)}
+      />
+
+      {/* 사유 입력 모달 (그룹 탈퇴) */}
+      <ReasonModal
+        open={showLeaveReasonModal}
+        title="그룹 탈퇴"
+        message="그룹에서 탈퇴하시겠습니까? 사유를 입력해 주세요."
+        placeholder="탈퇴 사유 (최대 100자)"
+        maxLength={100}
+        initialValue=""
+        confirmText="요청하기"
+        cancelText="취소"
+        isSubmitting={submittingLeave}
+        onConfirm={(reason) => {
+          void handleConfirmLeave(reason)
+        }}
+        onCancel={() => setShowLeaveReasonModal(false)}
       />
     </>
   )


### PR DESCRIPTION
## Purpose
- 그룹 탈퇴 요청 플로우(UI + API)를 추가
- 마이페이지에서 사유 입력 → 탈퇴 요청 생성 → “그룹장 승인 대기” 표시까지 동작하며, 그룹에 속해 있는 경우 회원 탈퇴를 막고 안내 모달을 노출

## Changes
- 공용 `ReasonModal` 컴포넌트 추가(사유 입력)
- 그룹 탈퇴 API 연동: `POST /api/groups/{groupId}/leave-requests`
- 훅 추가: `useRequestGroupLeave` (요청 생성 및 관련 캐시 무효화)
- 마이페이지 UI 수정
  - “그룹 탈퇴” 버튼 → 사유 입력 모달 → 요청하기
  - 요청 성공 시 “그룹장 승인 대기” 배지 표시
  - 그룹 가입 상태에서 “회원 탈퇴” 클릭 시 안내 모달 노출

## Screenshots/GIF
(필요 시 추가)

## How to test
1. 그룹에 속한 계정으로 로그인 후 `/mypage` 진입
2. **그룹 탈퇴** 클릭 → 사유 입력 후 **요청하기** → 안내 모달 표시 및 “그룹장 승인 대기” 배지 확인
3. 같은 상태에서 **회원 탈퇴** 클릭 → “그룹 탈퇴를 먼저 진행” 안내 모달 노출 확인
4. 그룹이 없는 계정에서 **회원 탈퇴** → 확인/완료 플로우 동작 확인


## Checklist
- [ ] `npm run lint`를 실행하여 린트 오류가 없습니다

