### PR TITLE
feat:알림 api 연동

### DIFF
--- a/src/components/NotificationSidebar.tsx
+++ b/src/components/NotificationSidebar.tsx
@@ -1,9 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useMemo } from 'react'
 import { Bell, X, Trash2, Check } from 'lucide-react'
-import { getNotifications, markNotificationAsRead, deleteAllNotifications } from '../libs/api/notifications'
-import { Notification } from '../types/notification'
+
 import { useAuth } from '../contexts/AuthContext'
-import { useNotifications } from '../libs/hooks/useNotifications'
+import {
+  useDeleteAllNotifications,
+  useMarkNotificationRead,
+  useNotificationList,
+  useNotifications,
+} from '../libs/hooks/useNotifications'
 
 interface NotificationSidebarProps {
   isOpen: boolean
@@ -11,12 +15,13 @@ interface NotificationSidebarProps {
 }
 
 export default function NotificationSidebar({ isOpen, onClose }: NotificationSidebarProps) {
-  const [notifications, setNotifications] = useState<Notification[]>([])
-  const [loading, setLoading] = useState(false)
-  const [deleting, setDeleting] = useState(false)
   const { isAuthenticated } = useAuth()
   const { updateUnreadCount } = useNotifications()
-  
+
+  const { data: list = [], isLoading, refetch } = useNotificationList()
+  const { mutateAsync: markRead } = useMarkNotificationRead()
+  const { mutateAsync: clearAll, isPending: deleting } = useDeleteAllNotifications()
+
   // 터치 제스처를 위한 ref와 상태
   const sidebarRef = useRef<HTMLDivElement>(null)
   const [touchStart, setTouchStart] = useState<number | null>(null)
@@ -33,47 +38,38 @@ export default function NotificationSidebar({ isOpen, onClose }: NotificationSid
 
   const handleTouchEnd = () => {
     if (!touchStart || !touchEnd) return
-    
+
     const distance = touchStart - touchEnd
     const isLeftSwipe = distance > 50 // 왼쪽으로 50px 이상 스와이프
-    
+
     if (isLeftSwipe) {
       onClose() // 왼쪽으로 스와이프하면 사이드바 닫기
     }
-    
+
     setTouchStart(null)
     setTouchEnd(null)
   }
 
-  // 알림 목록 조회
-  const fetchNotifications = async () => {
-    if (!isAuthenticated) return
-    
-    try {
-      setLoading(true)
-      const notificationsData = await getNotifications()
-      setNotifications(notificationsData)
-    } catch (error) {
-      console.error('알림 조회 실패:', error)
-    } finally {
-      setLoading(false)
-    }
-  }
+  // 사이드바 열릴 때만 최신화
+  useEffect(() => {
+    if (isOpen && isAuthenticated) refetch()
+  }, [isOpen, isAuthenticated, refetch])
+
+  // 목록 기준으로 미읽음 자동 동기화(navBar 뱃지)
+  const unreadCount = useMemo(() => list.filter((n) => !n.read).length, [list])
+  useEffect(() => {
+    if (isOpen) updateUnreadCount(unreadCount)
+  }, [isOpen, unreadCount, updateUnreadCount])
 
   // 알림 읽음 처리
   const handleMarkAsRead = async (notificationId: number) => {
+    // 이미 읽음이면 스킵
+    const target = list.find((n) => n.id === notificationId)
+    if (!target || target.read) return
+
     try {
-      await markNotificationAsRead(notificationId)
-      setNotifications(prev => 
-        prev.map(notif => 
-          notif.id === notificationId 
-            ? { ...notif, read: true, readAt: new Date().toISOString() }
-            : notif
-        )
-      )
-      
-      // 읽지 않은 개수 업데이트
-      updateUnreadCount(notifications.filter(n => !n.read).length - 1)
+      await markRead(notificationId) // 낙관적 업데이트/롤백은 훅 내부에서 처리
+      // 미읽음 뱃지는 list 변화에 반응하는 useEffect가 자동 반영
     } catch (error) {
       console.error('알림 읽음 처리 실패:', error)
     }
@@ -82,16 +78,11 @@ export default function NotificationSidebar({ isOpen, onClose }: NotificationSid
   // 모든 알림 삭제
   const handleDeleteAll = async () => {
     if (!confirm('모든 알림을 삭제하시겠습니까?')) return
-    
     try {
-      setDeleting(true)
-      await deleteAllNotifications()
-      setNotifications([])
-      updateUnreadCount(0)
-    } catch (error) {
-      console.error('알림 삭제 실패:', error)
-    } finally {
-      setDeleting(false)
+      await clearAll()
+      updateUnreadCount(0) // 즉시 뱃지 0
+    } catch (e) {
+      console.error('알림 삭제 실패:', e)
     }
   }
 
@@ -131,33 +122,27 @@ export default function NotificationSidebar({ isOpen, onClose }: NotificationSid
     const date = new Date(dateString)
     const now = new Date()
     const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60))
-    
+
     if (diffInHours < 1) return '방금 전'
     if (diffInHours < 24) return `${diffInHours}시간 전`
     if (diffInHours < 48) return '어제'
     return date.toLocaleDateString('ko-KR')
   }
 
-  useEffect(() => {
-    if (isOpen && isAuthenticated) {
-      fetchNotifications()
-    }
-  }, [isOpen, isAuthenticated])
-
   if (!isOpen) return null
 
   return (
     <div className="fixed inset-0 z-50 overflow-hidden">
       {/* Overlay */}
-      <div 
+      <div
         className={`absolute inset-0 bg-black transition-all duration-500 ease-in-out ${
           isOpen ? 'bg-opacity-50 opacity-100' : 'bg-opacity-0 opacity-0'
         }`}
         onClick={onClose}
       />
-      
+
       {/* Sidebar - 모바일에서는 모바일 메뉴와 동일한 스타일과 애니메이션, 데스크톱에서는 기존 스타일 */}
-      <div 
+      <div
         ref={sidebarRef}
         className={`absolute right-0 top-0 h-full bg-base-100 min-h-full border-r z-[99999]
                    w-72 sm:w-80 md:w-96 lg:w-96
@@ -177,17 +162,13 @@ export default function NotificationSidebar({ isOpen, onClose }: NotificationSid
           <div className="flex items-center gap-2">
             <button
               onClick={handleDeleteAll}
-              disabled={deleting || notifications.length === 0}
-              className="btn btn-ghost btn-sm text-red-600 hover:bg-red-50 p-2 sm:p-3"
+              disabled={deleting || list.length === 0}
+              className="btn btn-sm text-red-600 hover:bg-red-50 p-2 sm:p-3 rounded-lg"
               title="모든 알림 삭제"
             >
               <Trash2 className="w-4 h-4" />
             </button>
-            <button
-              onClick={onClose}
-              className="btn btn-ghost btn-sm p-2 sm:p-3"
-              aria-label="닫기"
-            >
+            <button onClick={onClose} className="btn btn-ghost btn-sm p-2 sm:p-3" aria-label="닫기">
               <X className="w-5 h-5" />
             </button>
           </div>
@@ -195,39 +176,41 @@ export default function NotificationSidebar({ isOpen, onClose }: NotificationSid
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
-          {loading ? (
+          {isLoading ? (
             <div className="flex items-center justify-center p-6 sm:p-8">
               <div className="loading loading-spinner loading-md"></div>
             </div>
-          ) : notifications.length === 0 ? (
+          ) : list.length === 0 ? (
             <div className="flex flex-col items-center justify-center p-6 sm:p-8 text-gray-500">
               <Bell className="w-10 h-10 sm:w-12 sm:h-12 mb-4 opacity-50" />
               <p className="text-center text-sm sm:text-base">새로운 알림이 없습니다</p>
             </div>
           ) : (
             <div className="p-3 sm:p-4 space-y-2 sm:space-y-3">
-              {notifications.map((notification) => (
+              {list.map((notification) => (
                 <div
                   key={notification.id}
                   className={`p-3 sm:p-4 rounded-lg border transition-all ${
-                    notification.read 
-                      ? 'bg-gray-50 border-gray-200' 
-                      : 'bg-blue-50 border-blue-200'
+                    notification.read ? 'bg-gray-50 border-gray-200' : 'bg-blue-50 border-blue-200'
                   }`}
                 >
                   <div className="flex items-start gap-2 sm:gap-3">
-                    <div className={`text-xl sm:text-2xl ${getNotificationColor(notification.type)}`}>
+                    <div
+                      className={`text-xl sm:text-2xl ${getNotificationColor(notification.type)}`}
+                    >
                       {getNotificationIcon(notification.type)}
                     </div>
-                    
+
                     <div className="flex-1 min-w-0">
                       <div className="flex items-start justify-between gap-2">
-                        <h3 className={`font-medium text-sm ${
-                          notification.read ? 'text-gray-700' : 'text-gray-900'
-                        }`}>
+                        <h3
+                          className={`font-medium text-sm ${
+                            notification.read ? 'text-gray-700' : 'text-gray-900'
+                          }`}
+                        >
                           {notification.title}
                         </h3>
-                        
+
                         {!notification.read && (
                           <button
                             onClick={() => handleMarkAsRead(notification.id)}
@@ -238,17 +221,21 @@ export default function NotificationSidebar({ isOpen, onClose }: NotificationSid
                           </button>
                         )}
                       </div>
-                      
-                      <p className={`text-sm mt-1 ${
-                        notification.read ? 'text-gray-600' : 'text-gray-800'
-                      }`}>
+
+                      <p
+                        className={`text-sm mt-1 ${
+                          notification.read ? 'text-gray-600' : 'text-gray-800'
+                        }`}
+                      >
                         {notification.content}
                       </p>
-                      
+
                       <div className="flex items-center justify-between mt-2">
-                        <span className={`text-xs ${
-                          notification.read ? 'text-gray-500' : 'text-blue-600'
-                        }`}>
+                        <span
+                          className={`text-xs ${
+                            notification.read ? 'text-gray-500' : 'text-blue-600'
+                          }`}
+                        >
                           {notification.read ? '읽음' : '읽지 않음'}
                         </span>
                         <span className="text-xs text-gray-500">

--- a/src/libs/hooks/useNotifications.ts
+++ b/src/libs/hooks/useNotifications.ts
@@ -1,13 +1,21 @@
 import { useState, useEffect, useCallback } from 'react'
 import {
+  createNotification,
+  deleteAllNotifications,
+  getNotifications,
   getNotificationsSettings,
   getUnreadCount,
+  markNotificationAsRead,
   NotificationSettings,
   updateNotificationsSettings,
 } from '../api/notifications'
 import { useAuth } from '../../contexts/AuthContext'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useProfile } from './mypage/useProfile'
+import {
+  CreateNotificationRequest,
+  Notification as AppNotification,
+} from '../../types/notification'
 
 export const useNotifications = () => {
   const [unreadCount, setUnreadCount] = useState(0)
@@ -79,13 +87,80 @@ export function useNotificationsSettings() {
 /** 알림 설정 저장 (PUT /api/notifications/settings) */
 export function useUpdateNotificationSetting() {
   const qc = useQueryClient()
+  const { data: me } = useProfile()
   return useMutation({
     mutationFn: (body: NotificationSettings) => updateNotificationsSettings(body),
     onSuccess: (_data, body) => {
       // 즉시 캐시 갱신
-      qc.setQueryData(NOTI_SETTINGS_KEY, body)
+      qc.setQueryData([NOTI_SETTINGS_KEY, me?.id], body)
       // 저장 후 목록 재검증
-      qc.invalidateQueries({ queryKey: NOTI_SETTINGS_KEY })
+      qc.invalidateQueries({ queryKey: [NOTI_SETTINGS_KEY, me?.id] })
+    },
+  })
+}
+
+export const NOTI_LIST_KEY = ['notifications', 'list'] as const
+export const NOTI_UNREAD_KEY = ['notifications', 'unread-count'] as const
+
+// 알림 목록 조회
+export function useNotificationList() {
+  return useQuery<AppNotification[]>({
+    queryKey: NOTI_LIST_KEY,
+    queryFn: () => getNotifications(),
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  })
+}
+
+/** 단건 읽음 처리 */
+export function useMarkNotificationRead() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: number) => markNotificationAsRead(id),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: NOTI_LIST_KEY })
+      const prev = qc.getQueryData<AppNotification[]>(NOTI_LIST_KEY)
+      qc.setQueryData<AppNotification[]>(NOTI_LIST_KEY, (old) =>
+        (old ?? []).map((n) =>
+          n.id === id ? { ...n, read: true, readAt: new Date().toISOString() } : n
+        )
+      )
+      qc.setQueryData(NOTI_UNREAD_KEY, (c: { count: number } | undefined) =>
+        c ? { count: Math.max(0, c.count - 1) } : c
+      )
+      return { prev }
+    },
+    onError: (_e, _id, ctx) => {
+      if (ctx?.prev) qc.setQueryData(NOTI_LIST_KEY, ctx.prev)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: NOTI_LIST_KEY })
+      qc.invalidateQueries({ queryKey: NOTI_UNREAD_KEY })
+    },
+  })
+}
+
+/** 전체 삭제 */
+export function useDeleteAllNotifications() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => deleteAllNotifications(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: NOTI_LIST_KEY })
+      qc.invalidateQueries({ queryKey: NOTI_UNREAD_KEY })
+    },
+  })
+}
+
+/** 알림 생성 (테스트/관리자 UI용) */
+export function useCreateNotification() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (args: { body: CreateNotificationRequest; isAppActive?: boolean }) =>
+      createNotification(args.body, args.isAppActive ?? false),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: NOTI_LIST_KEY })
+      qc.invalidateQueries({ queryKey: NOTI_UNREAD_KEY })
     },
   })
 }


### PR DESCRIPTION
## Purpose
알림 사이드바 및 관련 훅을 구현하여 사용자가 알림을 조회, 읽음 처리, 삭제할 수 있도록 api 연동

## Changes
- 알림 목록 조회 훅(`useNotificationList`) 추가
- 알림 읽음 처리 훅(`useMarkNotificationRead`) 추가
- 알림 전체 삭제 훅(`useDeleteAllNotifications`) 추가

## Screenshots/GIF
<!-- 알림 사이드바 동작 화면 첨부 예정 -->

## How to test
1. 로그인 후 우측 상단 종 아이콘을 클릭하여 알림 사이드바 열기
2. 알림 읽음 버튼 클릭 시 해당 알림이 읽음 처리되는지 확인
3. "모든 알림 삭제" 버튼 클릭 시 알림이 전체 삭제되는지 확인

## Checklist
- [ ] `npm run lint`를 실행하여 린트 오류가 없습니다

